### PR TITLE
Chore: upgrade package_info_plus to 10.2.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -297,6 +297,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -402,10 +410,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      sha256: "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -732,18 +740,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      sha256: f5c435dc0e0d461e5b32471a870f769b6a1cc46930637efe24fbc535314e78ad
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.1"
+    version: "10.2.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "4.1.0"
   path:
     dependency: "direct main"
     description:
@@ -1177,10 +1185,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.3.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   bloc: ^9.2.0
   flutter_bloc: ^9.1.1
   intl: ^0.20.2
-  package_info_plus: ^9.0.0
+  package_info_plus: ^10.0.0
   openai_dart: ^0.6.2
   aws_s3_upload_lite: ^0.1.7
   uuid: ^4.0.0


### PR DESCRIPTION
## Summary

Upgrades `package_info_plus` **9 → 10.2.0** (major). No application code changes required.

> **Stacked on #8** (`dependency_refresh`). GitHub will auto-retarget the base to `main` once #8 merges.

## Why it's safe

The only usage in the app is `PackageInfo.fromPlatform()` + `.version` (`lib/main.dart:23,27`, surfaced in the About row). Neither changed in v10.

Per the 10.0.0 changelog, the "breaking" change is **purely platform/dependency floors** (from bumping `win32` 5→6):
- Min Flutter 3.41.6 — we're on **3.44.4** ✓
- Min Dart 3.11.0 — we're on **3.12.2** ✓
- Min macOS 10.15 — our deployment target is **15.0** ✓

No API surface changed for our usage.

## Changes

- `pubspec.yaml`: `package_info_plus: ^9.0.0` → `^10.0.0`
- `pubspec.lock`: `package_info_plus` 9.0.1→10.2.0, `package_info_plus_platform_interface` 3.2.1→4.1.0, plus its Windows-only transitives (`win32` 5.15→6.3, `flutter_secure_storage_windows`) — not compiled on macOS.

## Verification (Flutter 3.44.4 / Dart 3.12.2)

- `flutter analyze` → **No issues found**
- `flutter test` → **all 616 tests pass**
- `flutter build macos` → **built**
- Smoke-launch → clean startup (exercises `PackageInfo.fromPlatform()` at boot)
