### PR TITLE
Chore: upgrade openai_dart to 7.0.1

### DIFF
--- a/lib/src/ai/openai/openai_service.dart
+++ b/lib/src/ai/openai/openai_service.dart
@@ -9,7 +9,7 @@ class OpenAiService {
 
   void initialize(String apiKey) {
     _apiKey = apiKey;
-    _client = OpenAIClient(apiKey: apiKey);
+    _client = OpenAIClient.withApiKey(apiKey);
   }
 
   bool get isInitialized => _client != null && _apiKey != null;
@@ -32,17 +32,14 @@ class OpenAiService {
         maxTags: maxTags,
       );
 
-      final response = await _client!.createChatCompletion(
-        request: CreateChatCompletionRequest(
-          model: const ChatCompletionModel.modelId('gpt-3.5-turbo'),
+      final response = await _client!.chat.completions.create(
+        ChatCompletionCreateRequest(
+          model: 'gpt-3.5-turbo',
           messages: [
-            const ChatCompletionMessage.system(
-              content:
-                  'You are a helpful assistant that analyzes web content and generates structured bookmark metadata. Respond only with valid JSON.',
+            ChatMessage.system(
+              'You are a helpful assistant that analyzes web content and generates structured bookmark metadata. Respond only with valid JSON.',
             ),
-            ChatCompletionMessage.user(
-              content: ChatCompletionUserMessageContent.string(prompt),
-            ),
+            ChatMessage.user(prompt),
           ],
           maxTokens: 300,
           temperature: 0.3,
@@ -128,14 +125,10 @@ IMPORTANT: Respond ONLY with valid JSON in this exact format:
     if (!isInitialized) return false;
 
     try {
-      final response = await _client!.createChatCompletion(
-        request: const CreateChatCompletionRequest(
-          model: ChatCompletionModel.modelId('gpt-3.5-turbo'),
-          messages: [
-            ChatCompletionMessage.user(
-              content: ChatCompletionUserMessageContent.string('Hello'),
-            ),
-          ],
+      final response = await _client!.chat.completions.create(
+        ChatCompletionCreateRequest(
+          model: 'gpt-3.5-turbo',
+          messages: [ChatMessage.user('Hello')],
           maxTokens: 5,
         ),
       );
@@ -154,7 +147,7 @@ IMPORTANT: Respond ONLY with valid JSON in this exact format:
 
     try {
       // Get available models to verify permissions
-      final modelsResponse = await _client!.listModels();
+      final modelsResponse = await _client!.models.list();
       final models = modelsResponse.data;
 
       // Filter for models we care about
@@ -170,14 +163,10 @@ IMPORTANT: Respond ONLY with valid JSON in this exact format:
       // Try a minimal completion to verify chat permissions
       bool canChat = false;
       try {
-        final testResponse = await _client!.createChatCompletion(
-          request: const CreateChatCompletionRequest(
-            model: ChatCompletionModel.modelId('gpt-3.5-turbo'),
-            messages: [
-              ChatCompletionMessage.user(
-                content: ChatCompletionUserMessageContent.string('Hi'),
-              ),
-            ],
+        final testResponse = await _client!.chat.completions.create(
+          ChatCompletionCreateRequest(
+            model: 'gpt-3.5-turbo',
+            messages: [ChatMessage.user('Hi')],
             maxTokens: 1,
           ),
         );
@@ -210,7 +199,7 @@ IMPORTANT: Respond ONLY with valid JSON in this exact format:
   }
 
   void dispose() {
-    _client?.endSession();
+    _client?.close();
     _client = null;
     _apiKey = null;
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -424,14 +424,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  freezed_annotation:
-    dependency: transitive
-    description:
-      name: freezed_annotation
-      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -724,10 +716,10 @@ packages:
     dependency: "direct main"
     description:
       name: openai_dart
-      sha256: "037605a210cb3b1d8ac72b11a4ace26f25ee9267aaf981d2af1d7f0524adcbf5"
+      sha256: c2d690fb68ae56a913872a1347fa11294fea9cf373e6fdf0b253754d83f1e779
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "7.0.1"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   flutter_bloc: ^9.1.1
   intl: ^0.20.2
   package_info_plus: ^10.0.0
-  openai_dart: ^0.6.2
+  openai_dart: ^7.0.0
   aws_s3_upload_lite: ^0.1.7
   uuid: ^4.0.0
   json_serializable: ^6.11.2


### PR DESCRIPTION
## Summary

Upgrades `openai_dart` **0.6.2 → 7.0.1** (major). v1.0.0 rewrote the package from a flat client into a **resource-based API** (matching the official OpenAI SDKs), so `lib/src/ai/openai/openai_service.dart` is migrated to the new surface. No behavioral change — same requests, same response/error handling.

> **Stacked on #9 → #8.** GitHub auto-retargets the base to `main` as the chain merges.

## API migration (per the package `MIGRATION.md`)

| Old (0.6.2) | New (7.x) |
|---|---|
| `OpenAIClient(apiKey: k)` | `OpenAIClient.withApiKey(k)` |
| `client.createChatCompletion(request: CreateChatCompletionRequest(…))` | `client.chat.completions.create(ChatCompletionCreateRequest(…))` |
| `model: ChatCompletionModel.modelId('gpt-3.5-turbo')` | `model: 'gpt-3.5-turbo'` |
| `ChatCompletionMessage.system(content: s)` | `ChatMessage.system(s)` |
| `ChatCompletionMessage.user(content: ChatCompletionUserMessageContent.string(p))` | `ChatMessage.user(p)` |
| `client.listModels()` | `client.models.list()` |
| `client.endSession()` | `client.close()` |

Unchanged: `response.choices.first.message.content`, `ModelList.data` / `Model.id`, `maxTokens`/`temperature` fields, and all the surrounding logic (`analyzeContent`, `testConnection`, `getApiKeyInfo`, error-code string matching).

## Scope

- `pubspec.yaml`: `openai_dart: ^0.6.2` → `^7.0.0`
- `pubspec.lock`: `openai_dart` 0.6.2 → 7.0.1 (+ transitives)
- `lib/src/ai/openai/openai_service.dart`: 6 call sites migrated

The v1→v7 breaking changes (Realtime API GA, Responses API, reasoning context, `FunctionCallStatus`, `McpTool.serverUrl`) are all in surfaces this app does not use.

## Verification (Flutter 3.44.4 / Dart 3.12.2)

- `flutter analyze` → **No issues found**
- `flutter test` → **all 616 tests pass** (the AI tests mock the `OpenAiService` wrapper, so they cover the call path into this file)
- `flutter build macos` → **built**; app launches clean

⚠️ **Reviewer note:** `openai_service.dart` has no direct unit test and the OpenAI calls require a live API key, so **runtime request-shape correctness is not automatically verified** — analyze confirms it compiles against 7.x and the logic is a 1:1 port, but a manual check of the AI bookmark-suggestion flow with a real key is recommended before release.
