### PR TITLE
Fix: drop pod install from release pipeline after SPM migration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -128,9 +128,6 @@ jobs:
           set -euo pipefail
           echo "🔧 Resolving Swift Package Manager dependencies..."
 
-          # CocoaPods (ensure workspace is up to date)
-          (cd macos && pod install)
-
           # Resolve SPM packages
           xcodebuild -resolvePackageDependencies \
             -workspace macos/Runner.xcworkspace \

--- a/build_release.sh
+++ b/build_release.sh
@@ -68,14 +68,6 @@ rm -rf build/macos
 rm -rf macos/Flutter/ephemeral
 rm -rf macos/.symlinks
 
-# 5. Update CocoaPods
-print_status "Updating CocoaPods..."
-cd macos
-pod repo update
-pod install --repo-update
-cd ..
-check_error "CocoaPods update failed"
-
 # 6. Build the release app
 print_status "Building macOS release app..."
 flutter build macos --release --verbose


### PR DESCRIPTION
## Summary

Fixes the release pipeline broken by the CocoaPods → SPM migration (#10). The macOS `Podfile` was removed, but two release paths still ran `pod install`:

```
[!] No `Podfile' found in the project directory.
Error: Process completed with exit code 1.
```

## Changes

- **`.github/workflows/publish.yml`** — the "Resolve Swift Package Manager dependencies" step dropped `(cd macos && pod install)`. The `xcodebuild -resolvePackageDependencies -workspace macos/Runner.xcworkspace -scheme Runner` call (SPM resolution) is kept.
- **`build_release.sh`** — removed the "Update CocoaPods" block (`pod repo update` / `pod install --repo-update`). SPM is resolved automatically by `flutter build macos --release`.

## Verification

- Ran the exact CI command locally with **no Podfile present**:
  `xcodebuild -resolvePackageDependencies -workspace macos/Runner.xcworkspace -scheme Runner -configuration Release` → **exit 0**, resolved all SPM packages (`FlutterGeneratedPluginSwiftPackage`, `macos_ui`, `macos_window_utils`, `sqlite3_flutter_libs`, `url_launcher_macos`, `appkit_ui_element_colors`, …).
- `flutter build macos --release` handling SPM without CocoaPods was already confirmed in #10.
- Grepped the repo: no remaining `pod install` / `Podfile` references in any workflow or release script.
