### PR TITLE
Fix: update bundle framework check for SPM static linking

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -195,7 +195,7 @@ jobs:
           echo ""
 
           # Then check for required frameworks
-          REQUIRED_FRAMEWORKS=("FlutterMacOS.framework" "appkit_ui_element_colors.framework")
+          REQUIRED_FRAMEWORKS=("FlutterMacOS.framework" "App.framework")
           for framework in "${REQUIRED_FRAMEWORKS[@]}"; do
             if [[ -d "$APP_PATH/Contents/Frameworks/$framework" ]]; then
               echo "✅ Found: $framework"

--- a/build_release.sh
+++ b/build_release.sh
@@ -92,7 +92,7 @@ fi
 
 # 9. Check for required frameworks
 print_status "Checking for critical frameworks..."
-CRITICAL_FRAMEWORKS=("FlutterMacOS.framework" "appkit_ui_element_colors.framework")
+CRITICAL_FRAMEWORKS=("FlutterMacOS.framework" "App.framework")
 for framework in "${CRITICAL_FRAMEWORKS[@]}"; do
     if [ -d "$APP_PATH/Contents/Frameworks/$framework" ]; then
         print_success "Found: $framework"


### PR DESCRIPTION
## Summary

Second release-pipeline fix from the CocoaPods → SPM migration (#10). The bundle framework check hardcoded `appkit_ui_element_colors.framework`, which no longer exists:

```
✅ Found: FlutterMacOS.framework
❌ Missing: appkit_ui_element_colors.framework
Error: Process completed with exit code 1.
```

## Why it broke

Under CocoaPods (`use_frameworks!`) every plugin shipped as its own dynamic `.framework`. **Swift Package Manager statically links** the Swift plugins into the app instead, so per-plugin frameworks like `appkit_ui_element_colors.framework` are gone. A local `flutter build macos --release` confirms the bundle now contains only:

```
App.framework  CSQLite.framework  FlutterMacOS.framework  objective_c.framework
```

`appkit_ui_element_colors` (and `macos_ui`, `macos_window_utils`, `url_launcher_macos`, …) are compiled into the app binary — their absence as frameworks is correct, not a build defect.

## Changes

Point the check at the two frameworks that are always present in a Flutter macOS SPM release bundle — the engine and the compiled Dart app:

- **`.github/workflows/publish.yml`** — `REQUIRED_FRAMEWORKS=("FlutterMacOS.framework" "App.framework")`
- **`build_release.sh`** — `CRITICAL_FRAMEWORKS=("FlutterMacOS.framework" "App.framework")`

## Verification

- `flutter build macos --release` → built (exit 0); listed frameworks match the CI output.
- Ran the exact fixed check against the local Release bundle → **both found, exit 0**.
