### PR TITLE
Fix: sidebar version stuck at 0.7.2 (sync with release tag)

### DIFF
--- a/build_release.sh
+++ b/build_release.sh
@@ -70,7 +70,17 @@ rm -rf macos/.symlinks
 
 # 6. Build the release app
 print_status "Building macOS release app..."
-flutter build macos --release --verbose
+# Derive the app version from the latest git tag (e.g. v0.9.0 -> 0.9.0) so the
+# in-app version (shown in the sidebar) always matches the release. Falls back
+# to the pubspec version when no reachable tag exists.
+APP_VERSION="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')"
+if [ -n "$APP_VERSION" ]; then
+    print_status "Using version $APP_VERSION (from latest git tag)"
+    flutter build macos --release --build-name="$APP_VERSION" --verbose
+else
+    print_warning "No git tag found; using pubspec version"
+    flutter build macos --release --verbose
+fi
 check_error "Flutter build failed"
 
 # 7. Verify the build

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pinboard_wizard
 description: "A MacOS client for pinboard"
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 0.7.2
+version: 0.9.0
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Bug

The sidebar footer always shows **Version 0.7.2**, even though the app has been released up through **`v0.9.0`** (tags: `v0.9.0`, `v0.8.0`, `v0.7.2`…).

## Root cause

The displayed version comes from `PackageInfo.fromPlatform()` → macOS `CFBundleShortVersionString`, which `Info.plist` maps to `$(FLUTTER_BUILD_NAME)`. Flutter derives `FLUTTER_BUILD_NAME` from pubspec's `version:` at build time.

Two things kept it frozen at 0.7.2:
1. **`pubspec.yaml` `version:` was never bumped past `0.7.2`** — the `v0.8.0` / `v0.9.0` releases were tagged but pubspec wasn't updated.
2. **`build_release.sh` runs `flutter build macos --release` without `--build-name`**, so release builds just inherit the stale pubspec version.

So every build since 0.7.2 embedded `0.7.2`, and the sidebar (correctly) displayed it. (Confirmed: the built app's `CFBundleShortVersionString` reads `0.7.2`.)

## Fix

- **Bump `pubspec.yaml` `version:` → `0.9.0`** to match the latest release tag (immediate correctness; also fixes `flutter run` / debug builds).
- **`build_release.sh` now derives the version from the latest git tag** (`git describe --tags --abbrev=0` → strip leading `v`) and passes it as `--build-name`, with a fallback to the pubspec version when no tag is reachable. This keeps the in-app version in sync with releases automatically, so it won't drift again.

## Verification

`fvm flutter build macos --debug` → built app now reports:
```
CFBundleShortVersionString = 0.9.0
```
Tag derivation resolves correctly: `git describe --tags --abbrev=0 | sed 's/^v//'` → `0.9.0`. Sidebar now shows **Version 0.9.0**.

🤖 Generated with an AI coding agent.
