### PR TITLE
feat: iCloud credential sync + .env import

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,56 @@ User settings are stored in the macOS app container. The app handles:
 
 ![Backup Settings](docs/screenshots/backup-settings.png)
 
+## Syncing credentials across Macs (iCloud)
+
+Pinboard Wizard can sync all of its credentials — Pinboard API token, OpenAI
+and Jina keys, S3 backup configuration, and GitHub notes credentials — across
+your Macs using iCloud Keychain.
+
+- Open **Settings → Sync** and enable **Sync credentials across devices**.
+- Sync is **off by default** and must be enabled on **each Mac** that should
+  participate. It requires iCloud Keychain (System Settings → Apple ID →
+  iCloud → Passwords & Keychain).
+- When you enable sync on a Mac and a synced value already exists (from
+  another Mac), the synced value replaces the local one.
+- Disabling sync keeps a local snapshot of the current values and never
+  affects your other Macs.
+- Apple end-to-end encrypts iCloud Keychain data; no credential ever touches
+  a third-party server.
+
+## Importing credentials from a .env file
+
+Instead of typing each credential into Settings, you can import them once from
+a `.env` file via **Settings → Sync → Import from .env…**.
+
+Recognized variables:
+
+| Variable | Maps to |
+|---|---|
+| `PINBOARD_API_TOKEN` | Pinboard API token (`username:hex`) |
+| `OPENAI_API_KEY` | OpenAI API key |
+| `JINA_API_KEY` | Jina AI key |
+| `AWS_ACCESS_KEY_ID` | S3 backup access key |
+| `AWS_SECRET_ACCESS_KEY` | S3 backup secret key |
+| `AWS_REGION` | S3 backup region |
+| `S3_BUCKET` | S3 backup bucket name |
+| `S3_FILE_PATH` | S3 backup file path |
+| `GITHUB_PAT` | GitHub personal access token |
+| `GITHUB_OWNER` | GitHub repository owner |
+| `GITHUB_REPO` | GitHub repository name |
+| `GITHUB_BRANCH` | GitHub branch (default `main`) |
+| `GITHUB_NOTES_PATH` | Notes folder inside the repository |
+
+Rules:
+
+- Import is **one-time**: the app reads the file only when you click Import,
+  never at launch. You can delete the file afterwards.
+- Values from the file **replace** existing stored values ("env wins").
+  Variables not present in the file are left untouched.
+- Unrecognized variables and unparseable lines are ignored and reported.
+- Standard `.env` syntax is supported: `KEY=VALUE`, optional `export `
+  prefix, `#` comments, single or double quotes.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/README.md
+++ b/README.md
@@ -422,7 +422,9 @@ Rules:
 - Variables with empty values are ignored — an import never clears a stored
   credential.
 - Standard `.env` syntax is supported: `KEY=VALUE`, optional `export `
-  prefix, `#` comments, single or double quotes.
+  prefix, `#` comments, single or double quotes. In unquoted values an
+  inline `#` preceded by whitespace starts a comment and is stripped;
+  quoted values keep `#` intact.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ Rules:
 - Values from the file **replace** existing stored values ("env wins").
   Variables not present in the file are left untouched.
 - Unrecognized variables and unparseable lines are ignored and reported.
+- Variables with empty values are ignored — an import never clears a stored
+  credential.
 - Standard `.env` syntax is supported: `KEY=VALUE`, optional `export `
   prefix, `#` comments, single or double quotes.
 

--- a/docs/superpowers/plans/2026-07-10-credential-sync-and-env-import.md
+++ b/docs/superpowers/plans/2026-07-10-credential-sync-and-env-import.md
@@ -1,0 +1,2338 @@
+# Credential Sync & Env Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Share all five credential groups across Macs via iCloud Keychain (opt-in toggle) and support one-time credential import from a `.env` file.
+
+**Architecture:** A new `AppSecureStorage` centralizes all keychain access and owns the per-item `synchronizable` attribute plus enable/disable migration. The four credential services are refactored to inject it. A new `EnvImportService` parses `.env` content and applies recognized variables through the existing services. A new "Sync" tab in Settings hosts the toggle and import flow.
+
+**Tech Stack:** Flutter 3.44.4 (via `fvm`), `flutter_secure_storage` 10.3.1 (already latest — verified on pub.dev 2026-07-10; no upgrade needed), new dep `file_selector` ^1.0.3, `bloc`/`flutter_bloc`, `mocktail`/`mockito` for tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-credential-sync-and-env-import-design.md`
+
+## Global Constraints
+
+- macOS desktop only; run tests with `fvm flutter test <path>`, analyze with `fvm flutter analyze`, format with `fvm dart format .`.
+- Keychain keys (existing, MUST NOT change): `pinboard_credentials`, `ai_settings`, `backup_s3_config`, `github_notes_config`, `github_pat_token`.
+- Sync flag keychain key: `secrets_sync_enabled` — ALWAYS stored local-only (never synchronizable).
+- Sync toggle default OFF. Enabling: synced value wins over local; local-only copies deleted after adoption. Disabling: snapshot synced values to local-only; NEVER delete synchronizable items (deletion propagates to other Macs).
+- Env import: explicit action only; env value always wins; keys absent from file are untouched; unrecognized lines ignored and counted.
+- Recognized env variables (exact names): `PINBOARD_API_TOKEN`, `OPENAI_API_KEY`, `JINA_API_KEY`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `S3_BUCKET`, `S3_FILE_PATH`, `GITHUB_PAT`, `GITHUB_OWNER`, `GITHUB_REPO`, `GITHUB_BRANCH`, `GITHUB_NOTES_PATH`.
+- `flutter_secure_storage` 10.3.1 API (verified): `read`/`write`/`delete`/`containsKey` each take `mOptions: AppleOptions?`; `MacOsOptions extends AppleOptions` and has `synchronizable` (default `false`).
+- Skip project-wide formatters/linters/test-suite during tasks; Task 10 runs them once.
+
+---
+
+### Task 1: `AppSecureStorage` core + migration tests
+
+**Files:**
+- Create: `lib/src/common/storage/app_secure_storage.dart`
+- Create: `test/common/storage/fake_flutter_secure_storage.dart`
+- Test: `test/common/storage/app_secure_storage_test.dart`
+
+**Interfaces:**
+- Consumes: `package:flutter_secure_storage/flutter_secure_storage.dart` (v10.3.1).
+- Produces (later tasks rely on these exact members):
+  - `class AppSecureStorage` with:
+    - `AppSecureStorage({FlutterSecureStorage storage = const FlutterSecureStorage()})`
+    - `Future<void> init()`
+    - `bool get syncEnabled`
+    - `Future<void> setSyncEnabled(bool enabled)`
+    - `Future<String?> read(String key)`
+    - `Future<void> write(String key, String value)`
+    - `Future<void> delete(String key)`
+    - `Future<bool> containsKey(String key)`
+    - `static const List<String> syncedKeys`
+  - `class AppSecureStorageException implements Exception` with `final String message`.
+  - Test fake: `class FakeFlutterSecureStorage extends Fake implements FlutterSecureStorage` exposing `final Map<String, String> local` and `final Map<String, String> synced`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/common/storage/fake_flutter_secure_storage.dart`:
+
+```dart
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// In-memory fake keyed by (key, synchronizable) — mirrors how the macOS
+/// keychain treats local-only and synchronizable items as distinct.
+class FakeFlutterSecureStorage extends Fake implements FlutterSecureStorage {
+  final Map<String, String> local = {};
+  final Map<String, String> synced = {};
+
+  Map<String, String> _bucket(AppleOptions? mOptions) {
+    final isSynced = mOptions != null && mOptions.synchronizable;
+    return isSynced ? synced : local;
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => _bucket(mOptions)[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      _bucket(mOptions).remove(key);
+    } else {
+      _bucket(mOptions)[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    _bucket(mOptions).remove(key);
+  }
+
+  @override
+  Future<bool> containsKey({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => _bucket(mOptions).containsKey(key);
+}
+```
+
+Create `test/common/storage/app_secure_storage_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+
+import 'fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage storage;
+
+  setUp(() {
+    fake = FakeFlutterSecureStorage();
+    storage = AppSecureStorage(storage: fake);
+  });
+
+  group('init', () {
+    test('defaults to sync disabled when no flag stored', () async {
+      await storage.init();
+      expect(storage.syncEnabled, isFalse);
+    });
+
+    test('loads persisted sync flag from local-only entry', () async {
+      fake.local['secrets_sync_enabled'] = 'true';
+      await storage.init();
+      expect(storage.syncEnabled, isTrue);
+    });
+  });
+
+  group('read/write/delete with sync disabled', () {
+    setUp(() async => storage.init());
+
+    test('writes land in the local bucket only', () async {
+      await storage.write('pinboard_credentials', 'secret');
+      expect(fake.local['pinboard_credentials'], 'secret');
+      expect(fake.synced.containsKey('pinboard_credentials'), isFalse);
+    });
+
+    test('reads ignore dormant synced items', () async {
+      fake.synced['pinboard_credentials'] = 'from-other-mac';
+      expect(await storage.read('pinboard_credentials'), isNull);
+    });
+
+    test('delete removes only the local item', () async {
+      fake.local['ai_settings'] = 'a';
+      fake.synced['ai_settings'] = 'b';
+      await storage.delete('ai_settings');
+      expect(fake.local.containsKey('ai_settings'), isFalse);
+      expect(fake.synced['ai_settings'], 'b');
+    });
+
+    test('containsKey checks the active bucket', () async {
+      fake.local['ai_settings'] = 'a';
+      expect(await storage.containsKey('ai_settings'), isTrue);
+      expect(await storage.containsKey('pinboard_credentials'), isFalse);
+    });
+  });
+
+  group('enabling sync', () {
+    setUp(() async => storage.init());
+
+    test('pushes local-only values into the synced set', () async {
+      fake.local['pinboard_credentials'] = 'mine';
+      await storage.setSyncEnabled(true);
+      expect(fake.synced['pinboard_credentials'], 'mine');
+      expect(fake.local.containsKey('pinboard_credentials'), isFalse);
+    });
+
+    test('synced value wins when both exist', () async {
+      fake.local['pinboard_credentials'] = 'mine';
+      fake.synced['pinboard_credentials'] = 'from-other-mac';
+      await storage.setSyncEnabled(true);
+      expect(fake.synced['pinboard_credentials'], 'from-other-mac');
+      expect(fake.local.containsKey('pinboard_credentials'), isFalse);
+      expect(await storage.read('pinboard_credentials'), 'from-other-mac');
+    });
+
+    test('persists the flag local-only and flips reads to synced set', () async {
+      await storage.setSyncEnabled(true);
+      expect(storage.syncEnabled, isTrue);
+      expect(fake.local['secrets_sync_enabled'], 'true');
+      expect(fake.synced.containsKey('secrets_sync_enabled'), isFalse);
+      await storage.write('ai_settings', 'x');
+      expect(fake.synced['ai_settings'], 'x');
+    });
+
+    test('migrates every known key', () async {
+      for (final key in AppSecureStorage.syncedKeys) {
+        fake.local[key] = 'value-$key';
+      }
+      await storage.setSyncEnabled(true);
+      for (final key in AppSecureStorage.syncedKeys) {
+        expect(fake.synced[key], 'value-$key');
+        expect(fake.local.containsKey(key), isFalse);
+      }
+    });
+  });
+
+  group('disabling sync', () {
+    setUp(() async {
+      await storage.init();
+      await storage.setSyncEnabled(true);
+    });
+
+    test('snapshots synced values to local WITHOUT deleting synced items', () async {
+      fake.synced['pinboard_credentials'] = 'shared';
+      await storage.setSyncEnabled(false);
+      expect(storage.syncEnabled, isFalse);
+      expect(fake.local['pinboard_credentials'], 'shared');
+      // CRITICAL: synced item must survive — deletion would propagate to
+      // every other Mac via iCloud.
+      expect(fake.synced['pinboard_credentials'], 'shared');
+    });
+
+    test('subsequent writes stay local and do not touch the synced set', () async {
+      fake.synced['pinboard_credentials'] = 'shared';
+      await storage.setSyncEnabled(false);
+      await storage.write('pinboard_credentials', 'local-edit');
+      expect(fake.local['pinboard_credentials'], 'local-edit');
+      expect(fake.synced['pinboard_credentials'], 'shared');
+    });
+  });
+
+  test('setSyncEnabled is a no-op when state already matches', () async {
+    await storage.init();
+    fake.local['pinboard_credentials'] = 'mine';
+    await storage.setSyncEnabled(false);
+    expect(fake.local['pinboard_credentials'], 'mine');
+    expect(fake.synced, isEmpty);
+  });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `fvm flutter test test/common/storage/app_secure_storage_test.dart`
+Expected: FAIL — `Error: Couldn't resolve the package 'pinboard_wizard/src/common/storage/app_secure_storage.dart'` (file does not exist yet).
+
+- [ ] **Step 3: Implement `AppSecureStorage`**
+
+Create `lib/src/common/storage/app_secure_storage.dart`:
+
+```dart
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// Central keychain access for all credential storage.
+///
+/// Owns the macOS keychain `synchronizable` attribute (iCloud Keychain sync).
+/// A keychain item is either local-only or synchronizable — the attribute is
+/// part of the item's identity, so all reads and writes must agree on it.
+/// This class is the single place that decides which set is active.
+class AppSecureStorage {
+  /// Local-only flag key. NEVER synchronizable (chicken-and-egg).
+  static const String syncFlagKey = 'secrets_sync_enabled';
+
+  /// Every keychain key that participates in iCloud sync migration.
+  /// Add new credential keys here when introducing new secret types.
+  static const List<String> syncedKeys = [
+    'pinboard_credentials',
+    'ai_settings',
+    'backup_s3_config',
+    'github_notes_config',
+    'github_pat_token',
+  ];
+
+  static const MacOsOptions _localOptions = MacOsOptions();
+  static const MacOsOptions _syncedOptions = MacOsOptions(synchronizable: true);
+
+  final FlutterSecureStorage _storage;
+  bool _syncEnabled = false;
+
+  AppSecureStorage({FlutterSecureStorage storage = const FlutterSecureStorage()})
+    : _storage = storage;
+
+  /// Whether credentials are read from / written to the iCloud-synced set.
+  bool get syncEnabled => _syncEnabled;
+
+  MacOsOptions get _current => _syncEnabled ? _syncedOptions : _localOptions;
+
+  /// Loads the persisted sync flag. Must be awaited during app setup before
+  /// any dependent service reads credentials.
+  Future<void> init() async {
+    try {
+      final value = await _storage.read(key: syncFlagKey, mOptions: _localOptions);
+      _syncEnabled = value == 'true';
+    } catch (_) {
+      _syncEnabled = false;
+    }
+  }
+
+  Future<String?> read(String key) => _storage.read(key: key, mOptions: _current);
+
+  Future<void> write(String key, String value) =>
+      _storage.write(key: key, value: value, mOptions: _current);
+
+  Future<void> delete(String key) => _storage.delete(key: key, mOptions: _current);
+
+  Future<bool> containsKey(String key) =>
+      _storage.containsKey(key: key, mOptions: _current);
+
+  /// Enables or disables iCloud sync, migrating all [syncedKeys].
+  ///
+  /// Enabling: an existing synced value (from another Mac) wins over the
+  /// local one; otherwise the local value is pushed up. Local-only copies are
+  /// deleted afterwards (safe: local deletes never propagate).
+  ///
+  /// Disabling: synced values are snapshotted into local-only items. The
+  /// synchronizable originals are LEFT UNTOUCHED — deleting a synchronizable
+  /// item propagates the deletion to every other Mac.
+  ///
+  /// The flag flips only after every key migrates; the migration is
+  /// idempotent, so a partial failure leaves the toggle unchanged and retry
+  /// is safe.
+  Future<void> setSyncEnabled(bool enabled) async {
+    if (enabled == _syncEnabled) {
+      return;
+    }
+    try {
+      if (enabled) {
+        for (final key in syncedKeys) {
+          final synced = await _storage.read(key: key, mOptions: _syncedOptions);
+          final local = await _storage.read(key: key, mOptions: _localOptions);
+          if (synced == null && local != null) {
+            await _storage.write(key: key, value: local, mOptions: _syncedOptions);
+          }
+          if (local != null) {
+            await _storage.delete(key: key, mOptions: _localOptions);
+          }
+        }
+      } else {
+        for (final key in syncedKeys) {
+          final synced = await _storage.read(key: key, mOptions: _syncedOptions);
+          if (synced != null) {
+            await _storage.write(key: key, value: synced, mOptions: _localOptions);
+          }
+        }
+      }
+      await _storage.write(
+        key: syncFlagKey,
+        value: enabled ? 'true' : 'false',
+        mOptions: _localOptions,
+      );
+      _syncEnabled = enabled;
+    } catch (e) {
+      throw AppSecureStorageException(
+        'Failed to ${enabled ? 'enable' : 'disable'} credential sync: $e',
+      );
+    }
+  }
+}
+
+class AppSecureStorageException implements Exception {
+  final String message;
+
+  const AppSecureStorageException(this.message);
+
+  @override
+  String toString() => 'AppSecureStorageException: $message';
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `fvm flutter test test/common/storage/app_secure_storage_test.dart`
+Expected: PASS (all tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/src/common/storage/app_secure_storage.dart test/common/storage/
+git commit -m "feat: add AppSecureStorage with iCloud keychain sync migration"
+```
+
+---
+
+### Task 2: Register in locator; refactor `FlutterSecureSecretsStorage`
+
+**Files:**
+- Modify: `lib/src/service_locator.dart`
+- Modify: `lib/src/pinboard/flutter_secure_secrets_storage.dart`
+- Modify: `lib/src/pinboard/credentials_service.dart` (constructor only)
+- Test: `test/pinboard/flutter_secure_secrets_storage_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `AppSecureStorage` from Task 1 (`read(String)`, `write(String, String)`, `delete(String)`, `containsKey(String)`).
+- Produces:
+  - `FlutterSecureSecretsStorage({required AppSecureStorage storage})` implementing the existing `SecretStorage` interface (`read()`, `save(Credentials)`, `clear()`), plus `Future<bool> hasCredentials()`.
+  - `CredentialsService({required SecretStorage storage})` (fallback default removed).
+  - Locator registers `AppSecureStorage` (initialized) before dependents.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/pinboard/flutter_secure_secrets_storage_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/pinboard/flutter_secure_secrets_storage.dart';
+import 'package:pinboard_wizard/src/pinboard/models/credentials.dart';
+
+import '../common/storage/fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage appStorage;
+  late FlutterSecureSecretsStorage storage;
+
+  setUp(() async {
+    fake = FakeFlutterSecureStorage();
+    appStorage = AppSecureStorage(storage: fake);
+    await appStorage.init();
+    storage = FlutterSecureSecretsStorage(storage: appStorage);
+  });
+
+  test('save and read round-trips credentials as JSON', () async {
+    await storage.save(const Credentials(apiKey: 'user:abcdef0123456789'));
+    final result = await storage.read();
+    expect(result, const Credentials(apiKey: 'user:abcdef0123456789'));
+    expect(fake.local['pinboard_credentials'], contains('user:abcdef0123456789'));
+  });
+
+  test('read returns null when nothing stored', () async {
+    expect(await storage.read(), isNull);
+  });
+
+  test('read returns null on corrupt JSON', () async {
+    fake.local['pinboard_credentials'] = 'not-json';
+    expect(await storage.read(), isNull);
+  });
+
+  test('clear removes stored credentials', () async {
+    await storage.save(const Credentials(apiKey: 'user:abcdef0123456789'));
+    await storage.clear();
+    expect(await storage.read(), isNull);
+    expect(await storage.hasCredentials(), isFalse);
+  });
+
+  test('hasCredentials reflects stored state', () async {
+    expect(await storage.hasCredentials(), isFalse);
+    await storage.save(const Credentials(apiKey: 'user:abcdef0123456789'));
+    expect(await storage.hasCredentials(), isTrue);
+  });
+
+  test('credentials written while synced are read back through synced set', () async {
+    await appStorage.setSyncEnabled(true);
+    await storage.save(const Credentials(apiKey: 'user:abcdef0123456789'));
+    expect(fake.synced.containsKey('pinboard_credentials'), isTrue);
+    expect(await storage.read(), const Credentials(apiKey: 'user:abcdef0123456789'));
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/pinboard/flutter_secure_secrets_storage_test.dart`
+Expected: FAIL — `FlutterSecureSecretsStorage` has no `storage` named parameter.
+
+- [ ] **Step 3: Refactor `FlutterSecureSecretsStorage`**
+
+Replace the entire contents of `lib/src/pinboard/flutter_secure_secrets_storage.dart` with:
+
+```dart
+import 'dart:convert';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/pinboard/models/credentials.dart';
+import 'package:pinboard_wizard/src/pinboard/secrets_storage.dart';
+
+class FlutterSecureSecretsStorage implements SecretStorage {
+  static const String _credentialsKey = 'pinboard_credentials';
+
+  final AppSecureStorage _storage;
+
+  FlutterSecureSecretsStorage({required AppSecureStorage storage})
+    : _storage = storage;
+
+  @override
+  Future<Credentials?> read() async {
+    try {
+      final credentialsJson = await _storage.read(_credentialsKey);
+
+      if (credentialsJson == null || credentialsJson.isEmpty) {
+        return null;
+      }
+
+      final Map<String, dynamic> credentialsMap =
+          json.decode(credentialsJson) as Map<String, dynamic>;
+
+      return Credentials.fromJson(credentialsMap);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> save(Credentials credentials) async {
+    try {
+      final credentialsJson = json.encode(credentials.toJson());
+      await _storage.write(_credentialsKey, credentialsJson);
+    } catch (e) {
+      throw SecureStorageException('Failed to save credentials: $e');
+    }
+  }
+
+  @override
+  Future<void> clear() async {
+    try {
+      await _storage.delete(_credentialsKey);
+    } catch (e) {
+      throw SecureStorageException('Failed to clear credentials: $e');
+    }
+  }
+
+  Future<bool> hasCredentials() async {
+    try {
+      final credentialsJson = await _storage.read(_credentialsKey);
+      return credentialsJson != null && credentialsJson.isNotEmpty;
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
+class SecureStorageException implements Exception {
+  final String message;
+
+  const SecureStorageException(this.message);
+
+  @override
+  String toString() => 'SecureStorageException: $message';
+}
+```
+
+Note: the old `clearAll()` (which called `deleteAll()` — dangerous now that local and synced items coexist) and `readAll()` are deliberately removed. They have no callers (`grep -r "clearAll\|readAll" lib test` shows only unrelated `clearAllAiSettings`/`clearAllNotes`/GitHub `clearAll`).
+
+- [ ] **Step 4: Remove the default-constructor fallback in `CredentialsService`**
+
+In `lib/src/pinboard/credentials_service.dart`, replace:
+
+```dart
+  CredentialsService({SecretStorage? storage})
+    : _storage = storage ?? FlutterSecureSecretsStorage() {
+    _loadInitial();
+  }
+```
+
+with:
+
+```dart
+  CredentialsService({required SecretStorage storage}) : _storage = storage {
+    _loadInitial();
+  }
+```
+
+The import of `flutter_secure_secrets_storage.dart` at the top of `credentials_service.dart` stays (the `hasCredentials()` cast still uses the type).
+
+- [ ] **Step 5: Register `AppSecureStorage` in the locator**
+
+In `lib/src/service_locator.dart`:
+
+Add import:
+
+```dart
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+```
+
+At the top of `setup()`, before the `locator..registerLazySingleton` cascade, add:
+
+```dart
+  // Central keychain access — must be initialized before any service reads
+  // credentials, because the sync flag decides which keychain set is active.
+  final appSecureStorage = AppSecureStorage();
+  await appSecureStorage.init();
+  locator.registerSingleton<AppSecureStorage>(appSecureStorage);
+```
+
+Change the `SecretStorage` registration to:
+
+```dart
+    ..registerLazySingleton<SecretStorage>(
+      () => FlutterSecureSecretsStorage(
+        storage: locator.get<AppSecureStorage>(),
+      ),
+    )
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `fvm flutter test test/pinboard/`
+Expected: PASS. If `credentials_service_test.dart` fails to compile because it constructs `CredentialsService()` with an optional storage, update those constructions to pass the existing `InMemorySecretsStorage` explicitly, e.g. `CredentialsService(storage: InMemorySecretsStorage())`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/src/service_locator.dart lib/src/pinboard/ test/pinboard/
+git commit -m "refactor: route pinboard credential storage through AppSecureStorage"
+```
+
+---
+
+### Task 3: Refactor `AiSettingsService` to injected storage
+
+**Files:**
+- Modify: `lib/src/ai/ai_settings_service.dart`
+- Modify: `lib/src/service_locator.dart`
+- Test: `test/ai/ai_settings_service_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `AppSecureStorage` (Task 1), `FakeFlutterSecureStorage` (Task 1).
+- Produces: `AiSettingsService({required AppSecureStorage storage})`. All other public members unchanged (`settings`, `openaiSettings`, `setOpenAiApiKey`, `setJinaApiKey`, `clearAllAiSettings`, …).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/ai/ai_settings_service_test.dart`:
+
+```dart
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+
+import '../common/storage/fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage appStorage;
+
+  setUp(() async {
+    fake = FakeFlutterSecureStorage();
+    appStorage = AppSecureStorage(storage: fake);
+    await appStorage.init();
+  });
+
+  test('persists OpenAI key under ai_settings via AppSecureStorage', () async {
+    final service = AiSettingsService(storage: appStorage);
+    await service.setOpenAiApiKey('sk-test-key');
+
+    final stored = json.decode(fake.local['ai_settings']!) as Map<String, dynamic>;
+    expect((stored['openai'] as Map<String, dynamic>)['apiKey'], 'sk-test-key');
+    expect(service.openaiSettings.apiKey, 'sk-test-key');
+  });
+
+  test('persists Jina key via AppSecureStorage', () async {
+    final service = AiSettingsService(storage: appStorage);
+    await service.setJinaApiKey('jina-test-key-123');
+
+    final stored = json.decode(fake.local['ai_settings']!) as Map<String, dynamic>;
+    expect(
+      (stored['webScraping'] as Map<String, dynamic>)['jinaApiKey'],
+      'jina-test-key-123',
+    );
+  });
+
+  test('loads previously stored settings on construction', () async {
+    fake.local['ai_settings'] = json.encode({
+      'isEnabled': true,
+      'openai': {'apiKey': 'sk-existing', 'descriptionMaxLength': 80, 'maxTags': 3},
+      'webScraping': {'jinaApiKey': null},
+    });
+
+    final service = AiSettingsService(storage: appStorage);
+    // _loadSettings is fire-and-forget in the constructor; let it complete.
+    await Future<void>.delayed(Duration.zero);
+
+    expect(service.settings.isEnabled, isTrue);
+    expect(service.openaiSettings.apiKey, 'sk-existing');
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/ai/ai_settings_service_test.dart`
+Expected: FAIL — `AiSettingsService` has no `storage` named parameter.
+
+- [ ] **Step 3: Refactor `AiSettingsService`**
+
+In `lib/src/ai/ai_settings_service.dart`:
+
+Replace the import of `flutter_secure_storage` with:
+
+```dart
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+```
+
+Replace:
+
+```dart
+  static const String _aiSettingsKey = 'ai_settings';
+  static const FlutterSecureStorage _secureStorage = FlutterSecureStorage();
+
+  AiSettings _settings = const AiSettings();
+```
+and the existing constructor:
+```dart
+  AiSettingsService() {
+    _loadSettings();
+  }
+```
+
+with:
+
+```dart
+  static const String _aiSettingsKey = 'ai_settings';
+
+  final AppSecureStorage _secureStorage;
+
+  AiSettings _settings = const AiSettings();
+
+  AiSettingsService({required AppSecureStorage storage})
+    : _secureStorage = storage {
+    _loadSettings();
+  }
+```
+
+Then update the three call sites (keeping surrounding logic identical):
+- `_loadSettings`: `_secureStorage.read(key: _aiSettingsKey)` → `_secureStorage.read(_aiSettingsKey)`
+- `_saveSettings`: `_secureStorage.write(key: _aiSettingsKey, value: settingsJson)` → `_secureStorage.write(_aiSettingsKey, settingsJson)`
+- `clearAllAiSettings`: `_secureStorage.delete(key: _aiSettingsKey)` → `_secureStorage.delete(_aiSettingsKey)`
+
+- [ ] **Step 4: Update the locator registration**
+
+In `lib/src/service_locator.dart`, change:
+
+```dart
+    ..registerLazySingleton<AiSettingsService>(() => AiSettingsService())
+```
+
+to:
+
+```dart
+    ..registerLazySingleton<AiSettingsService>(
+      () => AiSettingsService(storage: locator.get<AppSecureStorage>()),
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `fvm flutter test test/ai/`
+Expected: PASS (mockito-generated mocks of `AiSettingsService` are constructor-agnostic; if any test constructs the real service directly, inject `AppSecureStorage(storage: FakeFlutterSecureStorage())`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/src/ai/ai_settings_service.dart lib/src/service_locator.dart test/ai/
+git commit -m "refactor: route AI settings storage through AppSecureStorage"
+```
+
+---
+
+### Task 4: Refactor `BackupService` to injected storage
+
+**Files:**
+- Modify: `lib/src/backup/backup_service.dart`
+- Modify: `lib/src/service_locator.dart`
+- Test: `test/backup/backup_service_storage_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `AppSecureStorage` (Task 1).
+- Produces: `BackupService({required AppSecureStorage storage})`. All other public members unchanged (`s3Config`, `loadConfiguration`, `saveConfiguration`, `clearConfiguration`, …).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/backup/backup_service_storage_test.dart`:
+
+```dart
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/backup/backup_service.dart';
+import 'package:pinboard_wizard/src/backup/models/s3_config.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+
+import '../common/storage/fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage appStorage;
+  late BackupService service;
+
+  setUp(() async {
+    fake = FakeFlutterSecureStorage();
+    appStorage = AppSecureStorage(storage: fake);
+    await appStorage.init();
+    service = BackupService(storage: appStorage);
+  });
+
+  test('saveConfiguration persists under backup_s3_config', () async {
+    const config = S3Config(
+      accessKey: 'AKIA123',
+      secretKey: 'shhh',
+      region: 'eu-west-1',
+      bucketName: 'my-bucket',
+      filePath: 'backups/',
+    );
+
+    await service.saveConfiguration(config);
+
+    final stored =
+        json.decode(fake.local['backup_s3_config']!) as Map<String, dynamic>;
+    expect(stored['accessKey'], 'AKIA123');
+    expect(stored['secretKey'], 'shhh');
+    expect(service.s3Config, config);
+  });
+
+  test('loadConfiguration restores a stored config', () async {
+    fake.local['backup_s3_config'] = json.encode(const S3Config(
+      accessKey: 'AKIA123',
+      secretKey: 'shhh',
+      region: 'eu-west-1',
+      bucketName: 'my-bucket',
+    ).toJson());
+
+    await service.loadConfiguration();
+    expect(service.s3Config.accessKey, 'AKIA123');
+    expect(service.s3Config.bucketName, 'my-bucket');
+  });
+
+  test('clearConfiguration deletes the stored entry', () async {
+    fake.local['backup_s3_config'] = json.encode(const S3Config(
+      accessKey: 'AKIA123',
+      secretKey: 'shhh',
+      region: 'eu-west-1',
+      bucketName: 'my-bucket',
+    ).toJson());
+
+    await service.clearConfiguration();
+    expect(fake.local.containsKey('backup_s3_config'), isFalse);
+    expect(service.s3Config.isEmpty, isTrue);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/backup/backup_service_storage_test.dart`
+Expected: FAIL — `BackupService` has no `storage` named parameter.
+
+- [ ] **Step 3: Refactor `BackupService`**
+
+In `lib/src/backup/backup_service.dart`:
+
+Replace the `flutter_secure_storage` import with:
+
+```dart
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+```
+
+Replace:
+
+```dart
+  static const String _s3ConfigKey = 'backup_s3_config';
+  static const FlutterSecureStorage _secureStorage = FlutterSecureStorage();
+```
+
+with:
+
+```dart
+  static const String _s3ConfigKey = 'backup_s3_config';
+
+  final AppSecureStorage _secureStorage;
+
+  BackupService({required AppSecureStorage storage}) : _secureStorage = storage;
+```
+
+Update the three call sites:
+- `loadConfiguration`: `_secureStorage.read(key: _s3ConfigKey)` → `_secureStorage.read(_s3ConfigKey)`
+- `saveConfiguration`: `_secureStorage.write(key: _s3ConfigKey, value: configJson)` → `_secureStorage.write(_s3ConfigKey, configJson)`
+- `clearConfiguration`: `_secureStorage.delete(key: _s3ConfigKey)` → `_secureStorage.delete(_s3ConfigKey)`
+
+- [ ] **Step 4: Update the locator registration**
+
+In `lib/src/service_locator.dart`, change:
+
+```dart
+    ..registerLazySingleton<BackupService>(() => BackupService())
+```
+
+to:
+
+```dart
+    ..registerLazySingleton<BackupService>(
+      () => BackupService(storage: locator.get<AppSecureStorage>()),
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `fvm flutter test test/backup/backup_service_storage_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/src/backup/backup_service.dart lib/src/service_locator.dart test/backup/
+git commit -m "refactor: route S3 backup config storage through AppSecureStorage"
+```
+
+---
+
+### Task 5: Refactor `GitHubCredentialsStorage` to injected storage
+
+**Files:**
+- Modify: `lib/src/github/github_credentials_storage.dart`
+- Modify: `lib/src/service_locator.dart`
+- Test: `test/github/github_credentials_storage_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `AppSecureStorage` (Task 1).
+- Produces: `GitHubCredentialsStorage({required AppSecureStorage storage})`. All other public members unchanged (`readConfig`, `readToken`, `saveConfig`, `saveToken`, `saveAll`, `isConfigured`, `clearConfig`, `clearToken`, `clearAll`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/github/github_credentials_storage_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/github/github_credentials_storage.dart';
+import 'package:pinboard_wizard/src/github/models/github_notes_config.dart';
+
+import '../common/storage/fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage appStorage;
+  late GitHubCredentialsStorage storage;
+
+  const config = GitHubNotesConfig(
+    owner: 'octocat',
+    repo: 'notes',
+    deviceId: 'device-1',
+    isConfigured: true,
+  );
+
+  setUp(() async {
+    fake = FakeFlutterSecureStorage();
+    appStorage = AppSecureStorage(storage: fake);
+    await appStorage.init();
+    storage = GitHubCredentialsStorage(storage: appStorage);
+  });
+
+  test('saveAll persists config and token under their keychain keys', () async {
+    await storage.saveAll(config: config, token: 'ghp_token123');
+
+    expect(fake.local['github_notes_config'], contains('octocat'));
+    expect(fake.local['github_pat_token'], 'ghp_token123');
+  });
+
+  test('readConfig and readToken round-trip', () async {
+    await storage.saveAll(config: config, token: 'ghp_token123');
+
+    final readBack = await storage.readConfig();
+    expect(readBack?.owner, 'octocat');
+    expect(readBack?.repo, 'notes');
+    expect(await storage.readToken(), 'ghp_token123');
+    expect(await storage.isConfigured(), isTrue);
+  });
+
+  test('clearAll removes both entries', () async {
+    await storage.saveAll(config: config, token: 'ghp_token123');
+    await storage.clearAll();
+
+    expect(await storage.readConfig(), isNull);
+    expect(await storage.readToken(), isNull);
+    expect(await storage.isConfigured(), isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/github/github_credentials_storage_test.dart`
+Expected: FAIL — `GitHubCredentialsStorage` has no `storage` named parameter.
+
+- [ ] **Step 3: Refactor `GitHubCredentialsStorage`**
+
+In `lib/src/github/github_credentials_storage.dart`:
+
+Replace the `flutter_secure_storage` import with:
+
+```dart
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+```
+
+Replace:
+
+```dart
+  static const FlutterSecureStorage _secureStorage = FlutterSecureStorage();
+```
+
+with:
+
+```dart
+  final AppSecureStorage _secureStorage;
+
+  GitHubCredentialsStorage({required AppSecureStorage storage})
+    : _secureStorage = storage;
+```
+
+Update the five call sites:
+- `readConfig`: `_secureStorage.read(key: _configKey)` → `_secureStorage.read(_configKey)`
+- `readToken`: `_secureStorage.read(key: _tokenKey)` → `_secureStorage.read(_tokenKey)`
+- `saveConfig`: `_secureStorage.write(key: _configKey, value: configJson)` → `_secureStorage.write(_configKey, configJson)`
+- `saveToken`: `_secureStorage.write(key: _tokenKey, value: token)` → `_secureStorage.write(_tokenKey, token)`
+- `clearConfig` / `clearToken`: `_secureStorage.delete(key: …)` → `_secureStorage.delete(…)`
+
+- [ ] **Step 4: Update the locator registration**
+
+In `lib/src/service_locator.dart`, change:
+
+```dart
+    ..registerLazySingleton<GitHubCredentialsStorage>(
+      () => GitHubCredentialsStorage(),
+    )
+```
+
+to:
+
+```dart
+    ..registerLazySingleton<GitHubCredentialsStorage>(
+      () => GitHubCredentialsStorage(storage: locator.get<AppSecureStorage>()),
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `fvm flutter test test/github/`
+Expected: PASS — `github_auth_service_test.dart` uses mockito-generated mocks of `GitHubCredentialsStorage`, which don't call the real constructor. If mock regeneration is needed: `fvm dart run build_runner build --delete-conflicting-outputs`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/src/github/github_credentials_storage.dart lib/src/service_locator.dart test/github/
+git commit -m "refactor: route GitHub credential storage through AppSecureStorage"
+```
+
+---
+
+### Task 6: `.env` file parser
+
+**Files:**
+- Create: `lib/src/env_import/env_file_parser.dart`
+- Test: `test/env_import/env_file_parser_test.dart`
+
+**Interfaces:**
+- Consumes: nothing project-specific.
+- Produces:
+  - `class ParsedEnvFile { final Map<String, String> variables; final int ignoredLines; const ParsedEnvFile({required this.variables, required this.ignoredLines}); }`
+  - `class EnvFileParser { ParsedEnvFile parse(String contents); }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/env_import/env_file_parser_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/env_import/env_file_parser.dart';
+
+void main() {
+  final parser = EnvFileParser();
+
+  test('parses simple KEY=VALUE lines', () {
+    final result = parser.parse('PINBOARD_API_TOKEN=user:abc123\n');
+    expect(result.variables, {'PINBOARD_API_TOKEN': 'user:abc123'});
+    expect(result.ignoredLines, 0);
+  });
+
+  test('strips export prefix', () {
+    final result = parser.parse('export OPENAI_API_KEY=sk-123');
+    expect(result.variables, {'OPENAI_API_KEY': 'sk-123'});
+  });
+
+  test('strips matching single and double quotes', () {
+    final result = parser.parse(
+      'A="double quoted"\nB=\'single quoted\'\nC="unbalanced\'',
+    );
+    expect(result.variables['A'], 'double quoted');
+    expect(result.variables['B'], 'single quoted');
+    expect(result.variables['C'], '"unbalanced\''); // mismatched quotes kept
+  });
+
+  test('skips blank lines and comments without counting them as ignored', () {
+    final result = parser.parse('\n# a comment\n\nKEY=value\n');
+    expect(result.variables, {'KEY': 'value'});
+    expect(result.ignoredLines, 0);
+  });
+
+  test('counts unparseable lines as ignored', () {
+    final result = parser.parse('not a var line\nKEY=value\n:::\n');
+    expect(result.variables, {'KEY': 'value'});
+    expect(result.ignoredLines, 2);
+  });
+
+  test('tolerates CRLF line endings', () {
+    final result = parser.parse('A=1\r\nB=2\r\n');
+    expect(result.variables, {'A': '1', 'B': '2'});
+  });
+
+  test('later duplicate keys win', () {
+    final result = parser.parse('A=first\nA=second\n');
+    expect(result.variables['A'], 'second');
+  });
+
+  test('keeps = signs inside values', () {
+    final result = parser.parse('TOKEN=abc=def==');
+    expect(result.variables['TOKEN'], 'abc=def==');
+  });
+
+  test('trims whitespace around key and value', () {
+    final result = parser.parse('  KEY  =  value  ');
+    expect(result.variables, {'KEY': 'value'});
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/env_import/env_file_parser_test.dart`
+Expected: FAIL — package import cannot be resolved (file does not exist).
+
+- [ ] **Step 3: Implement the parser**
+
+Create `lib/src/env_import/env_file_parser.dart`:
+
+```dart
+/// Result of parsing a `.env`-style file.
+class ParsedEnvFile {
+  /// Variable name → value (quotes stripped). Later duplicates win.
+  final Map<String, String> variables;
+
+  /// Number of non-empty, non-comment lines that could not be parsed.
+  final int ignoredLines;
+
+  const ParsedEnvFile({required this.variables, required this.ignoredLines});
+}
+
+/// Minimal `.env` parser: `KEY=VALUE` lines, optional `export ` prefix,
+/// surrounding single/double quotes stripped, `#` comment lines and blank
+/// lines skipped. Anything else is counted as ignored, never an error.
+class EnvFileParser {
+  static final RegExp _linePattern = RegExp(
+    r'^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$',
+  );
+
+  ParsedEnvFile parse(String contents) {
+    final variables = <String, String>{};
+    var ignored = 0;
+
+    for (final rawLine in contents.split(RegExp(r'\r?\n'))) {
+      final line = rawLine.trim();
+      if (line.isEmpty || line.startsWith('#')) {
+        continue;
+      }
+
+      final match = _linePattern.firstMatch(line);
+      if (match == null) {
+        ignored++;
+        continue;
+      }
+
+      variables[match.group(1)!] = _unquote(match.group(2)!.trim());
+    }
+
+    return ParsedEnvFile(variables: variables, ignoredLines: ignored);
+  }
+
+  String _unquote(String value) {
+    if (value.length >= 2) {
+      final first = value[0];
+      final last = value[value.length - 1];
+      if ((first == '"' && last == '"') || (first == "'" && last == "'")) {
+        return value.substring(1, value.length - 1);
+      }
+    }
+    return value;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `fvm flutter test test/env_import/env_file_parser_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/src/env_import/env_file_parser.dart test/env_import/env_file_parser_test.dart
+git commit -m "feat: add .env file parser"
+```
+
+---
+
+### Task 7: `EnvImportService`
+
+**Files:**
+- Create: `lib/src/env_import/env_import_service.dart`
+- Modify: `lib/src/service_locator.dart`
+- Test: `test/env_import/env_import_service_test.dart`
+
+**Interfaces:**
+- Consumes: `EnvFileParser`/`ParsedEnvFile` (Task 6), `CredentialsService.saveCredentials(String)`, `AiSettingsService.setOpenAiApiKey(String?)` / `setJinaApiKey(String?)`, `BackupService.loadConfiguration()` / `saveConfiguration(S3Config)` / `s3Config`, `GitHubCredentialsStorage.readConfig()` / `readToken()` / `saveConfig(GitHubNotesConfig)` / `saveToken(String)`, `GitHubAuthService.initialize()`, `Uuid().v4()`.
+- Produces:
+  - `class EnvImportPreview { final Map<String, String> recognized; final int ignoredLines; final List<String> unrecognized; }`
+  - `class EnvImportResult { final List<String> applied; final Map<String, String> failed; }`
+  - `class EnvImportService` with:
+    - constructor `EnvImportService({required CredentialsService credentialsService, required AiSettingsService aiSettingsService, required BackupService backupService, required GitHubCredentialsStorage githubStorage, required GitHubAuthService githubAuthService})`
+    - `static const Set<String> recognizedVariables`
+    - `EnvImportPreview preview(String contents)`
+    - `Future<EnvImportResult> apply(Map<String, String> variables)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/env_import/env_import_service_test.dart`. Uses real services over `FakeFlutterSecureStorage` (no HTTP is triggered by any code path used here); `GitHubAuthService` is real too — its `initialize()` only reads storage.
+
+```dart
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
+import 'package:pinboard_wizard/src/backup/backup_service.dart';
+import 'package:pinboard_wizard/src/backup/models/s3_config.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
+import 'package:pinboard_wizard/src/github/github_auth_service.dart';
+import 'package:pinboard_wizard/src/github/github_credentials_storage.dart';
+import 'package:pinboard_wizard/src/github/models/github_notes_config.dart';
+import 'package:pinboard_wizard/src/pinboard/credentials_service.dart';
+import 'package:pinboard_wizard/src/pinboard/flutter_secure_secrets_storage.dart';
+
+import '../common/storage/fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage appStorage;
+  late CredentialsService credentialsService;
+  late AiSettingsService aiSettingsService;
+  late BackupService backupService;
+  late GitHubCredentialsStorage githubStorage;
+  late GitHubAuthService githubAuthService;
+  late EnvImportService service;
+
+  setUp(() async {
+    fake = FakeFlutterSecureStorage();
+    appStorage = AppSecureStorage(storage: fake);
+    await appStorage.init();
+    credentialsService = CredentialsService(
+      storage: FlutterSecureSecretsStorage(storage: appStorage),
+    );
+    aiSettingsService = AiSettingsService(storage: appStorage);
+    backupService = BackupService(storage: appStorage);
+    githubStorage = GitHubCredentialsStorage(storage: appStorage);
+    githubAuthService = GitHubAuthService(storage: githubStorage);
+    service = EnvImportService(
+      credentialsService: credentialsService,
+      aiSettingsService: aiSettingsService,
+      backupService: backupService,
+      githubStorage: githubStorage,
+      githubAuthService: githubAuthService,
+    );
+  });
+
+  group('preview', () {
+    test('splits recognized from unrecognized variables', () {
+      final preview = service.preview(
+        'PINBOARD_API_TOKEN=user:abc\nAPPLE_ID=someone@example.com\njunk line\n',
+      );
+      expect(preview.recognized, {'PINBOARD_API_TOKEN': 'user:abc'});
+      expect(preview.unrecognized, ['APPLE_ID']);
+      expect(preview.ignoredLines, 1);
+    });
+  });
+
+  group('apply', () {
+    test('imports pinboard token and authenticates', () async {
+      final result = await service.apply({'PINBOARD_API_TOKEN': 'user:abc123def'});
+
+      expect(result.applied, contains('PINBOARD_API_TOKEN'));
+      expect(result.failed, isEmpty);
+      final creds = await credentialsService.getCredentials();
+      expect(creds?.apiKey, 'user:abc123def');
+    });
+
+    test('env value wins over an existing stored value', () async {
+      await credentialsService.saveCredentials('old:0000000000');
+      await service.apply({'PINBOARD_API_TOKEN': 'new:1111111111'});
+      final creds = await credentialsService.getCredentials();
+      expect(creds?.apiKey, 'new:1111111111');
+    });
+
+    test('imports AI keys', () async {
+      final result = await service.apply({
+        'OPENAI_API_KEY': 'sk-abc',
+        'JINA_API_KEY': 'jina-abc',
+      });
+
+      expect(result.applied, containsAll(['OPENAI_API_KEY', 'JINA_API_KEY']));
+      expect(aiSettingsService.openaiSettings.apiKey, 'sk-abc');
+      expect(aiSettingsService.settings.webScraping.jinaApiKey, 'jina-abc');
+    });
+
+    test('partial S3 import merges with the existing config', () async {
+      await backupService.saveConfiguration(const S3Config(
+        accessKey: 'OLD_ACCESS',
+        secretKey: 'OLD_SECRET',
+        region: 'us-east-1',
+        bucketName: 'old-bucket',
+      ));
+
+      await service.apply({'AWS_SECRET_ACCESS_KEY': 'NEW_SECRET'});
+
+      expect(backupService.s3Config.secretKey, 'NEW_SECRET');
+      expect(backupService.s3Config.accessKey, 'OLD_ACCESS');
+      expect(backupService.s3Config.bucketName, 'old-bucket');
+    });
+
+    test('creates a GitHub config with generated deviceId when none exists', () async {
+      final result = await service.apply({
+        'GITHUB_PAT': 'ghp_secret123',
+        'GITHUB_OWNER': 'octocat',
+        'GITHUB_REPO': 'notes',
+      });
+
+      expect(result.failed, isEmpty);
+      final config = await githubStorage.readConfig();
+      expect(config?.owner, 'octocat');
+      expect(config?.repo, 'notes');
+      expect(config?.branch, 'main');
+      expect(config?.deviceId, isNotEmpty);
+      expect(config?.isConfigured, isTrue);
+      expect(await githubStorage.readToken(), 'ghp_secret123');
+    });
+
+    test('merges GitHub fields into an existing config', () async {
+      await githubStorage.saveAll(
+        config: const GitHubNotesConfig(
+          owner: 'octocat',
+          repo: 'old-repo',
+          deviceId: 'device-1',
+          isConfigured: true,
+        ),
+        token: 'ghp_old',
+      );
+
+      await service.apply({'GITHUB_REPO': 'new-repo'});
+
+      final config = await githubStorage.readConfig();
+      expect(config?.repo, 'new-repo');
+      expect(config?.owner, 'octocat');
+      expect(config?.deviceId, 'device-1');
+      expect(await githubStorage.readToken(), 'ghp_old');
+    });
+
+    test('GitHub config without token is saved but not marked configured', () async {
+      await service.apply({'GITHUB_OWNER': 'octocat', 'GITHUB_REPO': 'notes'});
+
+      final config = await githubStorage.readConfig();
+      expect(config?.owner, 'octocat');
+      expect(config?.isConfigured, isFalse);
+    });
+
+    test('unknown variables are not applied', () async {
+      final result = await service.apply({'TOTALLY_UNKNOWN': 'x'});
+      expect(result.applied, isEmpty);
+      expect(result.failed, isEmpty);
+    });
+
+    test('a failing group is reported without blocking others', () async {
+      // Empty pinboard token makes CredentialsService.saveCredentials throw.
+      final result = await service.apply({
+        'PINBOARD_API_TOKEN': '   ',
+        'OPENAI_API_KEY': 'sk-abc',
+      });
+
+      expect(result.failed.keys, contains('PINBOARD_API_TOKEN'));
+      expect(result.applied, contains('OPENAI_API_KEY'));
+      expect(aiSettingsService.openaiSettings.apiKey, 'sk-abc');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/env_import/env_import_service_test.dart`
+Expected: FAIL — `env_import_service.dart` does not exist.
+
+- [ ] **Step 3: Implement `EnvImportService`**
+
+Create `lib/src/env_import/env_import_service.dart`:
+
+```dart
+import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
+import 'package:pinboard_wizard/src/backup/backup_service.dart';
+import 'package:pinboard_wizard/src/env_import/env_file_parser.dart';
+import 'package:pinboard_wizard/src/github/github_auth_service.dart';
+import 'package:pinboard_wizard/src/github/github_credentials_storage.dart';
+import 'package:pinboard_wizard/src/github/models/github_notes_config.dart';
+import 'package:pinboard_wizard/src/pinboard/credentials_service.dart';
+import 'package:uuid/uuid.dart';
+
+/// Preview of a parsed `.env` file, split into variables the app understands
+/// and everything else.
+class EnvImportPreview {
+  final Map<String, String> recognized;
+  final int ignoredLines;
+  final List<String> unrecognized;
+
+  const EnvImportPreview({
+    required this.recognized,
+    required this.ignoredLines,
+    required this.unrecognized,
+  });
+
+  bool get isEmpty => recognized.isEmpty;
+}
+
+/// Outcome of applying an import: which variables were written, and which
+/// failed with what message.
+class EnvImportResult {
+  final List<String> applied;
+  final Map<String, String> failed;
+
+  const EnvImportResult({required this.applied, required this.failed});
+}
+
+/// One-time import of credentials from `.env` file contents.
+///
+/// Env values always win over stored values; variables absent from the file
+/// are never touched. Writes go through the existing services so listeners
+/// (auth state, settings UI) update immediately.
+class EnvImportService {
+  static const Set<String> recognizedVariables = {
+    'PINBOARD_API_TOKEN',
+    'OPENAI_API_KEY',
+    'JINA_API_KEY',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_REGION',
+    'S3_BUCKET',
+    'S3_FILE_PATH',
+    'GITHUB_PAT',
+    'GITHUB_OWNER',
+    'GITHUB_REPO',
+    'GITHUB_BRANCH',
+    'GITHUB_NOTES_PATH',
+  };
+
+  static const _s3Variables = {
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_REGION',
+    'S3_BUCKET',
+    'S3_FILE_PATH',
+  };
+
+  static const _githubVariables = {
+    'GITHUB_PAT',
+    'GITHUB_OWNER',
+    'GITHUB_REPO',
+    'GITHUB_BRANCH',
+    'GITHUB_NOTES_PATH',
+  };
+
+  final CredentialsService _credentialsService;
+  final AiSettingsService _aiSettingsService;
+  final BackupService _backupService;
+  final GitHubCredentialsStorage _githubStorage;
+  final GitHubAuthService _githubAuthService;
+  final EnvFileParser _parser = EnvFileParser();
+  final Uuid _uuid = const Uuid();
+
+  EnvImportService({
+    required CredentialsService credentialsService,
+    required AiSettingsService aiSettingsService,
+    required BackupService backupService,
+    required GitHubCredentialsStorage githubStorage,
+    required GitHubAuthService githubAuthService,
+  }) : _credentialsService = credentialsService,
+       _aiSettingsService = aiSettingsService,
+       _backupService = backupService,
+       _githubStorage = githubStorage,
+       _githubAuthService = githubAuthService;
+
+  EnvImportPreview preview(String contents) {
+    final parsed = _parser.parse(contents);
+    final recognized = <String, String>{};
+    final unrecognized = <String>[];
+
+    for (final entry in parsed.variables.entries) {
+      if (recognizedVariables.contains(entry.key)) {
+        recognized[entry.key] = entry.value;
+      } else {
+        unrecognized.add(entry.key);
+      }
+    }
+
+    return EnvImportPreview(
+      recognized: recognized,
+      ignoredLines: parsed.ignoredLines,
+      unrecognized: unrecognized,
+    );
+  }
+
+  Future<EnvImportResult> apply(Map<String, String> variables) async {
+    final applied = <String>[];
+    final failed = <String, String>{};
+
+    // Pinboard
+    final pinboardToken = variables['PINBOARD_API_TOKEN'];
+    if (pinboardToken != null) {
+      try {
+        await _credentialsService.saveCredentials(pinboardToken);
+        applied.add('PINBOARD_API_TOKEN');
+      } catch (e) {
+        failed['PINBOARD_API_TOKEN'] = '$e';
+      }
+    }
+
+    // OpenAI / Jina
+    final openAiKey = variables['OPENAI_API_KEY'];
+    if (openAiKey != null) {
+      try {
+        await _aiSettingsService.setOpenAiApiKey(openAiKey);
+        applied.add('OPENAI_API_KEY');
+      } catch (e) {
+        failed['OPENAI_API_KEY'] = '$e';
+      }
+    }
+    final jinaKey = variables['JINA_API_KEY'];
+    if (jinaKey != null) {
+      try {
+        await _aiSettingsService.setJinaApiKey(jinaKey);
+        applied.add('JINA_API_KEY');
+      } catch (e) {
+        failed['JINA_API_KEY'] = '$e';
+      }
+    }
+
+    // S3 backup — merge into the existing config.
+    final s3Keys = variables.keys.where(_s3Variables.contains).toList();
+    if (s3Keys.isNotEmpty) {
+      try {
+        await _backupService.loadConfiguration();
+        final merged = _backupService.s3Config.copyWith(
+          accessKey: variables['AWS_ACCESS_KEY_ID'],
+          secretKey: variables['AWS_SECRET_ACCESS_KEY'],
+          region: variables['AWS_REGION'],
+          bucketName: variables['S3_BUCKET'],
+          filePath: variables['S3_FILE_PATH'],
+        );
+        await _backupService.saveConfiguration(merged);
+        applied.addAll(s3Keys);
+      } catch (e) {
+        for (final key in s3Keys) {
+          failed[key] = '$e';
+        }
+      }
+    }
+
+    // GitHub — merge into the existing config, or create one.
+    final githubKeys = variables.keys.where(_githubVariables.contains).toList();
+    if (githubKeys.isNotEmpty) {
+      try {
+        final existing = await _githubStorage.readConfig();
+        final token = variables['GITHUB_PAT'] ?? await _githubStorage.readToken();
+
+        final base = existing ??
+            GitHubNotesConfig(
+              owner: '',
+              repo: '',
+              deviceId: _uuid.v4(),
+            );
+        final owner = variables['GITHUB_OWNER'] ?? base.owner;
+        final repo = variables['GITHUB_REPO'] ?? base.repo;
+        final merged = base.copyWith(
+          owner: owner,
+          repo: repo,
+          branch: variables['GITHUB_BRANCH'] ?? base.branch,
+          notesPath: variables['GITHUB_NOTES_PATH'] ?? base.notesPath,
+          isConfigured:
+              owner.isNotEmpty && repo.isNotEmpty && (token?.isNotEmpty ?? false),
+        );
+
+        await _githubStorage.saveConfig(merged);
+        final importedToken = variables['GITHUB_PAT'];
+        if (importedToken != null) {
+          await _githubStorage.saveToken(importedToken);
+        }
+        await _githubAuthService.initialize();
+        applied.addAll(githubKeys);
+      } catch (e) {
+        for (final key in githubKeys) {
+          failed[key] = '$e';
+        }
+      }
+    }
+
+    return EnvImportResult(applied: applied, failed: failed);
+  }
+}
+```
+
+Note: `GitHubNotesConfig.copyWith` must include `owner`, `repo`, `branch`, and `notesPath` parameters — verify in `lib/src/github/models/github_notes_config.dart` (they exist; the model's copyWith covers all fields).
+
+- [ ] **Step 4: Register in the locator**
+
+In `lib/src/service_locator.dart`, add import:
+
+```dart
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
+```
+
+and add to the cascade (after `GitHubConfigValidator`):
+
+```dart
+    ..registerLazySingleton<EnvImportService>(
+      () => EnvImportService(
+        credentialsService: locator.get<CredentialsService>(),
+        aiSettingsService: locator.get<AiSettingsService>(),
+        backupService: locator.get<BackupService>(),
+        githubStorage: locator.get<GitHubCredentialsStorage>(),
+        githubAuthService: locator.get<GitHubAuthService>(),
+      ),
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `fvm flutter test test/env_import/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/src/env_import/ lib/src/service_locator.dart test/env_import/
+git commit -m "feat: add EnvImportService applying .env credentials through services"
+```
+
+---
+
+### Task 8: `SettingsState` + `SettingsCubit` additions
+
+**Files:**
+- Modify: `lib/src/pages/settings/state/settings_state.dart`
+- Modify: `lib/src/pages/settings/state/settings_cubit.dart`
+- Modify: `lib/src/pages/settings/settings_page.dart` (cubit construction only — the tab UI is Task 9)
+- Test: `test/pages/settings/state/settings_cubit_sync_test.dart` (create)
+
+**Interfaces:**
+- Consumes: `AppSecureStorage.syncEnabled` / `setSyncEnabled(bool)` (Task 1); `EnvImportService.preview` / `apply` (Task 7).
+- Produces:
+  - `SettingsState` gains: `final bool secretsSyncEnabled;` (default `false`) and `final String? envImportMessage;` (sentinel-nullable in `copyWith`, like `errorMessage`).
+  - `SettingsCubit` gains constructor params `required AppSecureStorage appSecureStorage, required EnvImportService envImportService` and methods:
+    - `Future<void> setSecretsSyncEnabled(bool enabled)`
+    - `EnvImportPreview previewEnvImport(String contents)`
+    - `Future<void> importEnvVariables(Map<String, String> variables)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/pages/settings/state/settings_cubit_sync_test.dart`:
+
+Note on real services: `loadSettings()` fire-and-forgets
+`_validateJinaKey`/`_validateOpenAiKey`, which call
+`AiSettingsService.testJinaConnection`/`testOpenAiConnection` →
+`locator.get<JinaService>()`/`locator.get<OpenAiService>()`. The locator is
+empty in this test, so those calls throw internally and are caught, leaving
+`jinaValidationStatus`/`openAiValidationStatus` as `invalid`. That is expected
+here — no network is touched, and none of these assertions read validation
+state. Do not "fix" it by registering services.
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
+import 'package:pinboard_wizard/src/backup/backup_service.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
+import 'package:pinboard_wizard/src/github/github_auth_service.dart';
+import 'package:pinboard_wizard/src/github/github_credentials_storage.dart';
+import 'package:pinboard_wizard/src/pages/settings/state/settings_cubit.dart';
+import 'package:pinboard_wizard/src/pinboard/credentials_service.dart';
+import 'package:pinboard_wizard/src/pinboard/flutter_secure_secrets_storage.dart';
+import 'package:pinboard_wizard/src/pinboard/pinboard_service.dart';
+import 'package:pinboard_wizard/src/pinboard/secrets_storage.dart';
+
+import '../../../common/storage/fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage appStorage;
+  late SettingsCubit cubit;
+  late SecretStorage secretStorage;
+  late CredentialsService credentialsService;
+  late AiSettingsService aiSettingsService;
+  late BackupService backupService;
+  late GitHubCredentialsStorage githubStorage;
+  late GitHubAuthService githubAuthService;
+
+  setUp(() async {
+    fake = FakeFlutterSecureStorage();
+    appStorage = AppSecureStorage(storage: fake);
+    await appStorage.init();
+    secretStorage = FlutterSecureSecretsStorage(storage: appStorage);
+    credentialsService = CredentialsService(storage: secretStorage);
+    aiSettingsService = AiSettingsService(storage: appStorage);
+    backupService = BackupService(storage: appStorage);
+    githubStorage = GitHubCredentialsStorage(storage: appStorage);
+    githubAuthService = GitHubAuthService(storage: githubStorage);
+    cubit = SettingsCubit(
+      credentialsService: credentialsService,
+      pinboardService: PinboardService(secretStorage: secretStorage),
+      aiSettingsService: aiSettingsService,
+      backupService: backupService,
+      githubAuthService: githubAuthService,
+      appSecureStorage: appStorage,
+      envImportService: EnvImportService(
+        credentialsService: credentialsService,
+        aiSettingsService: aiSettingsService,
+        backupService: backupService,
+        githubStorage: githubStorage,
+        githubAuthService: githubAuthService,
+      ),
+    );
+  });
+
+  tearDown(() => cubit.close());
+
+  test('loadSettings surfaces the persisted sync flag', () async {
+    fake.local['secrets_sync_enabled'] = 'true';
+    await appStorage.init();
+    await cubit.loadSettings();
+    expect(cubit.state.secretsSyncEnabled, isTrue);
+  });
+
+  test('setSecretsSyncEnabled(true) migrates and updates state', () async {
+    fake.local['pinboard_credentials'] = '{"apiKey":"user:abc"}';
+
+    await cubit.setSecretsSyncEnabled(true);
+
+    expect(cubit.state.secretsSyncEnabled, isTrue);
+    expect(fake.synced['pinboard_credentials'], '{"apiKey":"user:abc"}');
+  });
+
+  test('previewEnvImport reports recognized variables', () {
+    final preview = cubit.previewEnvImport('OPENAI_API_KEY=sk-1\nRANDOM=2\n');
+    expect(preview.recognized.keys, ['OPENAI_API_KEY']);
+    expect(preview.unrecognized, ['RANDOM']);
+  });
+
+  test('importEnvVariables applies values and sets a summary message', () async {
+    await cubit.importEnvVariables({'OPENAI_API_KEY': 'sk-1'});
+
+    expect(cubit.state.envImportMessage, contains('1'));
+    expect(aiSettingsService.openaiSettings.apiKey, 'sk-1');
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `fvm flutter test test/pages/settings/state/settings_cubit_sync_test.dart`
+Expected: FAIL — `SettingsCubit` has no `appSecureStorage` parameter.
+
+- [ ] **Step 3: Add state fields**
+
+In `lib/src/pages/settings/state/settings_state.dart`:
+
+Add to the constructor parameter list (after `this.tokenExpiryWarning,`):
+
+```dart
+    // Credential sync & import
+    this.secretsSyncEnabled = false,
+    this.envImportMessage,
+```
+
+Add fields (after `final TokenExpiryWarning? tokenExpiryWarning;`):
+
+```dart
+  // Credential sync & import
+  final bool secretsSyncEnabled;
+  final String? envImportMessage;
+```
+
+Add to `copyWith` parameters:
+
+```dart
+    bool? secretsSyncEnabled,
+    Object? envImportMessage = _sentinel,
+```
+
+Add to the `copyWith` body's `SettingsState(...)` construction:
+
+```dart
+      secretsSyncEnabled: secretsSyncEnabled ?? this.secretsSyncEnabled,
+      envImportMessage: envImportMessage == _sentinel
+          ? this.envImportMessage
+          : envImportMessage as String?,
+```
+
+Add both fields to the `props` list at the bottom of the class:
+
+```dart
+    secretsSyncEnabled,
+    envImportMessage,
+```
+
+- [ ] **Step 4: Extend `SettingsCubit`**
+
+In `lib/src/pages/settings/state/settings_cubit.dart`:
+
+Add imports:
+
+```dart
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
+```
+
+The existing constructor (lines 16-25) uses private named parameters
+(`required this._credentialsService,` — supported by this project's Dart
+version). Extend it in the same style — the full replacement:
+
+```dart
+  SettingsCubit({
+    required this._credentialsService,
+    required this._pinboardService,
+    required this._aiSettingsService,
+    required this._backupService,
+    required this._githubAuthService,
+    required this._appSecureStorage,
+    required this._envImportService,
+    GitHubConfigValidator? githubConfigValidator,
+  }) : _githubConfigValidator =
+           githubConfigValidator ?? GitHubConfigValidator(),
+       super(const SettingsState()) {
+    // Listen to authentication changes
+    _credentialsService.isAuthenticatedNotifier.addListener(_onAuthChanged);
+    // Listen to AI settings changes
+    _aiSettingsService.addListener(_onAiSettingsChanged);
+    // Listen to backup service changes
+    _backupService.addListener(_onBackupServiceChanged);
+    // Listen to GitHub auth changes
+    _githubAuthService.addListener(_onGitHubAuthChanged);
+  }
+```
+
+Add the two fields next to the existing service fields (after
+`final GitHubConfigValidator _githubConfigValidator;`):
+
+```dart
+  final AppSecureStorage _appSecureStorage;
+  final EnvImportService _envImportService;
+```
+
+In `loadSettings()`, include the flag in the loaded-state emit by adding to the `state.copyWith(...)` arguments:
+
+```dart
+          secretsSyncEnabled: _appSecureStorage.syncEnabled,
+```
+
+Add the three methods at the end of the class (before `close()` override if present):
+
+```dart
+  /// Enable or disable iCloud Keychain sync for all credentials.
+  Future<void> setSecretsSyncEnabled(bool enabled) async {
+    try {
+      await _appSecureStorage.setSyncEnabled(enabled);
+      _safeEmit(state.copyWith(secretsSyncEnabled: _appSecureStorage.syncEnabled));
+      // Reload so values adopted from the synced set appear in the UI.
+      await loadSettings();
+    } catch (e) {
+      _safeEmit(
+        state.copyWith(
+          errorMessage: 'Failed to ${enabled ? 'enable' : 'disable'} sync: $e',
+        ),
+      );
+    }
+  }
+
+  /// Parse .env contents into recognized/unrecognized variables.
+  EnvImportPreview previewEnvImport(String contents) =>
+      _envImportService.preview(contents);
+
+  /// Apply recognized env variables. Env values always win.
+  Future<void> importEnvVariables(Map<String, String> variables) async {
+    final result = await _envImportService.apply(variables);
+    final buffer = StringBuffer('Imported ${result.applied.length} value(s).');
+    if (result.failed.isNotEmpty) {
+      buffer.write(' Failed: ${result.failed.keys.join(', ')}.');
+    }
+    _safeEmit(state.copyWith(envImportMessage: buffer.toString()));
+    await loadSettings();
+  }
+```
+
+- [ ] **Step 5: Update `SettingsPage` cubit construction**
+
+In `lib/src/pages/settings/settings_page.dart`, extend the `BlocProvider` create:
+
+```dart
+      create: (context) => SettingsCubit(
+        credentialsService: locator.get<CredentialsService>(),
+        pinboardService: locator.get<PinboardService>(),
+        aiSettingsService: locator.get<AiSettingsService>(),
+        backupService: locator.get<BackupService>(),
+        githubAuthService: locator.get<GitHubAuthService>(),
+        appSecureStorage: locator.get<AppSecureStorage>(),
+        envImportService: locator.get<EnvImportService>(),
+      )..loadSettings(),
+```
+
+with imports:
+
+```dart
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
+```
+
+- [ ] **Step 6: Fix existing cubit tests' constructor calls**
+
+`test/pages/settings/state/settings_cubit_test.dart` and `test/pages/settings/state/settings_cubit_safe_emit_test.dart` construct `SettingsCubit` directly. For each construction site, add the two new arguments, backed by a fake storage per test file:
+
+```dart
+// at top of file
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
+import '../../../common/storage/fake_flutter_secure_storage.dart';
+```
+
+In `setUp`, build real instances over the fake (they are cheap and side-effect-free):
+
+```dart
+final appSecureStorage = AppSecureStorage(storage: FakeFlutterSecureStorage());
+```
+
+and pass:
+
+```dart
+  appSecureStorage: appSecureStorage,
+  envImportService: EnvImportService(
+    credentialsService: mockCredentialsService,
+    aiSettingsService: mockAiSettingsService,
+    backupService: mockBackupService,
+    githubStorage: GitHubCredentialsStorage(storage: appSecureStorage),
+    githubAuthService: mockGitHubAuthService,
+  ),
+```
+
+(using each file's existing mock instances — names may differ per file; keep their existing mocks.)
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `fvm flutter test test/pages/settings/`
+Expected: PASS (new sync test plus both existing cubit test files).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/src/pages/settings/ test/pages/settings/
+git commit -m "feat: expose credential sync toggle and env import in SettingsCubit"
+```
+
+---
+
+### Task 9: Settings UI "Sync" tab, `file_selector` dep, entitlements
+
+**Files:**
+- Modify: `pubspec.yaml`
+- Modify: `lib/src/pages/settings/settings_page.dart`
+- Modify: `macos/Runner/DebugProfile.entitlements`
+- Modify: `macos/Runner/Release.entitlements`
+
+**Interfaces:**
+- Consumes: `SettingsCubit.setSecretsSyncEnabled` / `previewEnvImport` / `importEnvVariables` (Task 8), `state.secretsSyncEnabled` / `state.envImportMessage`; UI kit: `AppTabView`, `AppTab`, `AppTabController`, `AppSwitch(value:, onChanged:)`, `AppButton(size:, secondary:, onPressed:, child:)`, `showAppAlertDialog` / `AppAlertDialog`, `context.appTypography`, `AppColors.separator`.
+- Produces: fifth Settings tab labeled `Sync`; no programmatic interface for later tasks.
+
+- [ ] **Step 1: Add the dependency**
+
+In `pubspec.yaml` under `dependencies:`, after `url_launcher: ^6.2.5`, add:
+
+```yaml
+  file_selector: ^1.0.3
+```
+
+Run: `fvm flutter pub get`
+Expected: resolves cleanly; `file_selector_macos` appears as a transitive (endorsed) dependency in `pubspec.lock`.
+
+- [ ] **Step 2: Add the sandbox entitlement for user-selected files**
+
+In `macos/Runner/DebugProfile.entitlements`, add inside the `<dict>`:
+
+```xml
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+```
+
+Same addition in `macos/Runner/Release.entitlements`.
+
+- [ ] **Step 3: Extend the tab bar**
+
+In `lib/src/pages/settings/settings_page.dart`:
+
+Change `AppTabController(length: 4)` to `AppTabController(length: 5)` in `initState`.
+
+In the `AppTabView`, append to `tabs`:
+
+```dart
+                    AppTab(label: 'Sync'),
+```
+
+and to `children`:
+
+```dart
+                    _buildSyncTab(context, state),
+```
+
+- [ ] **Step 4: Implement the tab body and flows**
+
+Add imports to `settings_page.dart`:
+
+```dart
+import 'package:file_selector/file_selector.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
+```
+
+Add these members to `_SettingsPageViewState`:
+
+```dart
+  Widget _buildSyncTab(BuildContext context, SettingsState state) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('iCloud Sync', style: context.appTypography.headline),
+          const SizedBox(height: 8),
+          Text(
+            'Sync your Pinboard, AI, backup, and GitHub credentials across '
+            'your Macs using iCloud Keychain. Requires iCloud Keychain to be '
+            'enabled in System Settings, and must be switched on separately '
+            'on each Mac.',
+            style: context.appTypography.body,
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              AppSwitch(
+                value: state.secretsSyncEnabled,
+                onChanged: (value) => _onSyncToggleChanged(context, value),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                'Sync credentials across devices',
+                style: context.appTypography.body,
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Container(height: 1, color: AppColors.separator),
+          const SizedBox(height: 16),
+          Text('Import from .env', style: context.appTypography.headline),
+          const SizedBox(height: 8),
+          Text(
+            'Import credentials from a .env file instead of entering them '
+            'manually. Values in the file replace existing ones; anything '
+            'not in the file is left unchanged. The file is read once — you '
+            'can delete it afterwards.',
+            style: context.appTypography.body,
+          ),
+          const SizedBox(height: 12),
+          AppButton(
+            size: AppButtonSize.large,
+            onPressed: () => _importEnvFile(context),
+            child: const Text('Import from .env…'),
+          ),
+          if (state.envImportMessage != null) ...[
+            const SizedBox(height: 12),
+            Text(state.envImportMessage!, style: context.appTypography.body),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Future<void> _onSyncToggleChanged(BuildContext context, bool value) async {
+    final cubit = context.read<SettingsCubit>();
+    if (!value) {
+      await cubit.setSecretsSyncEnabled(false);
+      return;
+    }
+    final confirmed = await showAppAlertDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AppAlertDialog(
+        title: const Text('Enable iCloud sync?'),
+        message: const Text(
+          'Your credentials will sync across Macs signed into the same '
+          'iCloud account. Where a synced value already exists, it replaces '
+          'this Mac\'s value.',
+        ),
+        primaryButton: AppAlertDialogAction(
+          label: 'Enable',
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+        ),
+        secondaryButton: AppAlertDialogAction(
+          label: 'Cancel',
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+        ),
+      ),
+    );
+    if (confirmed == true) {
+      await cubit.setSecretsSyncEnabled(true);
+    }
+  }
+
+  String _maskSecret(String value) {
+    if (value.length <= 8) return '••••';
+    return '${value.substring(0, 4)}…${value.substring(value.length - 4)}';
+  }
+
+  Future<void> _importEnvFile(BuildContext context) async {
+    final cubit = context.read<SettingsCubit>();
+    final file = await openFile(
+      acceptedTypeGroups: const [XTypeGroup(label: 'env files')],
+    );
+    if (file == null) return;
+
+    final String contents;
+    try {
+      contents = await file.readAsString();
+    } catch (e) {
+      if (!mounted) return;
+      await showAppAlertDialog<void>(
+        // ignore: use_build_context_synchronously
+        context: context,
+        builder: (dialogContext) => AppAlertDialog(
+          title: const Text('Could not read file'),
+          message: Text('$e'),
+          primaryButton: AppAlertDialogAction(
+            label: 'OK',
+            onPressed: () => Navigator.of(dialogContext).pop(),
+          ),
+        ),
+      );
+      return;
+    }
+
+    final preview = cubit.previewEnvImport(contents);
+    if (!mounted) return;
+
+    if (preview.isEmpty) {
+      await showAppAlertDialog<void>(
+        // ignore: use_build_context_synchronously
+        context: context,
+        builder: (dialogContext) => AppAlertDialog(
+          title: const Text('Nothing to import'),
+          message: Text(
+            'No recognized variables found. '
+            '${preview.unrecognized.isNotEmpty ? 'Unrecognized: ${preview.unrecognized.join(', ')}.' : ''}',
+          ),
+          primaryButton: AppAlertDialogAction(
+            label: 'OK',
+            onPressed: () => Navigator.of(dialogContext).pop(),
+          ),
+        ),
+      );
+      return;
+    }
+
+    final lines = preview.recognized.entries
+        .map((e) => '${e.key} = ${_maskSecret(e.value)}')
+        .join('\n');
+    final extra = <String>[
+      if (preview.unrecognized.isNotEmpty)
+        '${preview.unrecognized.length} unrecognized variable(s) ignored.',
+      if (preview.ignoredLines > 0)
+        '${preview.ignoredLines} unparseable line(s) ignored.',
+    ].join(' ');
+
+    final confirmed = await showAppAlertDialog<bool>(
+      // ignore: use_build_context_synchronously
+      context: context,
+      builder: (dialogContext) => AppAlertDialog(
+        title: const Text('Import credentials?'),
+        message: Text(
+          'The following values will be imported and will REPLACE any '
+          'existing values:\n\n$lines${extra.isNotEmpty ? '\n\n$extra' : ''}',
+        ),
+        primaryButton: AppAlertDialogAction(
+          label: 'Import',
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+        ),
+        secondaryButton: AppAlertDialogAction(
+          label: 'Cancel',
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+        ),
+      ),
+    );
+
+    if (confirmed == true) {
+      await cubit.importEnvVariables(preview.recognized);
+    }
+  }
+```
+
+**API-accuracy note:** `AppAlertDialog` / `showAppAlertDialog` / `AppAlertDialogAction` parameter names above follow the pattern visible in the GitHub tab (`settings_page.dart` ~line 1259). Before wiring the dialogs, open `lib/src/ui/overlays/` and match the real constructor signatures exactly (e.g. the action/button parameter names). Adjust the calls — not the flow — if names differ.
+
+- [ ] **Step 5: Build and smoke-test manually**
+
+Run: `fvm flutter build macos --debug`
+Expected: builds cleanly.
+
+Run: `make run`, then in the app:
+1. Settings → Sync tab renders; toggle is OFF.
+2. Click "Import from .env…", pick a scratch file containing `OPENAI_API_KEY=sk-test-123` and `APPLE_ID=x@y.z` → dialog lists `OPENAI_API_KEY = sk-t…-123`-style masked value and reports 1 unrecognized variable → Import → summary message appears, AI Settings tab shows the key.
+3. Flip the sync toggle ON → confirmation dialog → enable succeeds (verify in Keychain Access: the items appear in the iCloud keychain).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pubspec.yaml pubspec.lock lib/src/pages/settings/settings_page.dart macos/Runner/DebugProfile.entitlements macos/Runner/Release.entitlements
+git commit -m "feat: add Sync settings tab with iCloud toggle and .env import"
+```
+
+---
+
+### Task 10: README, full test suite, analyzer
+
+**Files:**
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: everything above; no new code.
+
+- [ ] **Step 1: Add README sections**
+
+In `README.md`, add a features/documentation section (place near the existing Settings/Backup documentation, matching the file's heading style):
+
+```markdown
+## Syncing credentials across Macs (iCloud)
+
+Pinboard Wizard can sync all of its credentials — Pinboard API token, OpenAI
+and Jina keys, S3 backup configuration, and GitHub notes credentials — across
+your Macs using iCloud Keychain.
+
+- Open **Settings → Sync** and enable **Sync credentials across devices**.
+- Sync is **off by default** and must be enabled on **each Mac** that should
+  participate. It requires iCloud Keychain (System Settings → Apple ID →
+  iCloud → Passwords & Keychain).
+- When you enable sync on a Mac and a synced value already exists (from
+  another Mac), the synced value replaces the local one.
+- Disabling sync keeps a local snapshot of the current values and never
+  affects your other Macs.
+- Apple end-to-end encrypts iCloud Keychain data; no credential ever touches
+  a third-party server.
+
+## Importing credentials from a .env file
+
+Instead of typing each credential into Settings, you can import them once from
+a `.env` file via **Settings → Sync → Import from .env…**.
+
+Recognized variables:
+
+| Variable | Maps to |
+|---|---|
+| `PINBOARD_API_TOKEN` | Pinboard API token (`username:hex`) |
+| `OPENAI_API_KEY` | OpenAI API key |
+| `JINA_API_KEY` | Jina AI key |
+| `AWS_ACCESS_KEY_ID` | S3 backup access key |
+| `AWS_SECRET_ACCESS_KEY` | S3 backup secret key |
+| `AWS_REGION` | S3 backup region |
+| `S3_BUCKET` | S3 backup bucket name |
+| `S3_FILE_PATH` | S3 backup file path |
+| `GITHUB_PAT` | GitHub personal access token |
+| `GITHUB_OWNER` | GitHub repository owner |
+| `GITHUB_REPO` | GitHub repository name |
+| `GITHUB_BRANCH` | GitHub branch (default `main`) |
+| `GITHUB_NOTES_PATH` | Notes folder inside the repository |
+
+Rules:
+
+- Import is **one-time**: the app reads the file only when you click Import,
+  never at launch. You can delete the file afterwards.
+- Values from the file **replace** existing stored values ("env wins").
+  Variables not present in the file are left untouched.
+- Unrecognized variables and unparseable lines are ignored and reported.
+- Standard `.env` syntax is supported: `KEY=VALUE`, optional `export `
+  prefix, `#` comments, single or double quotes.
+```
+
+- [ ] **Step 2: Run the full verification suite**
+
+```bash
+fvm dart format .
+fvm flutter analyze
+fvm flutter test
+```
+
+Expected: format makes no unexpected changes, analyzer reports no new issues, full test suite passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document credential sync and .env import"
+```
+
+---
+
+## Manual cross-Mac smoke checklist (not CI-testable — include in PR description)
+
+1. Mac A: configure Pinboard token, enable Settings → Sync. Confirm items in Keychain Access show as iCloud keychain items.
+2. Mac B (same iCloud account, iCloud Keychain on): install build, open Settings → Sync, enable. Pinboard token appears; app authenticates.
+3. Mac B: change the OpenAI key. Mac A: relaunch → sees the new key.
+4. Mac B: disable sync, change the Jina key. Mac A: key unchanged (divergence is expected and local to B).
+5. Mac B: re-enable sync → Mac B adopts A's synced values again.

--- a/docs/superpowers/specs/2026-07-10-credential-sync-and-env-import-design.md
+++ b/docs/superpowers/specs/2026-07-10-credential-sync-and-env-import-design.md
@@ -1,0 +1,177 @@
+# Credential Sync & Env Import Design
+
+**Date:** 2026-07-10
+**Status:** Approved (design) — pending implementation plan
+**Topic:** Share credentials across Macs via iCloud Keychain and import credentials from a `.env` file
+
+## Goal
+
+Let a user configure Pinboard Wizard's credentials once and have them available
+on every Mac they use, and optionally bootstrap all credentials from a `.env`
+file instead of typing each value into Settings inputs. Covers all five
+credential groups: Pinboard API token, OpenAI API key, Jina API key, S3 backup
+config, and GitHub notes config + PAT.
+
+## Constraints & Decisions
+
+- **Platform:** macOS desktop only. All credentials already live in the macOS
+  Keychain via `flutter_secure_storage` (v10) under five keys:
+  `pinboard_credentials`, `ai_settings`, `backup_s3_config`,
+  `github_notes_config`, `github_pat_token`.
+- **Sync transport (decided):** iCloud Keychain, using the keychain item
+  attribute `synchronizable` (`MacOsOptions(synchronizable: true)`). No custom
+  server, no custom crypto — Apple handles end-to-end encryption. Requires the
+  user to have iCloud Keychain enabled; devices are Macs on the same iCloud
+  account. Custom sync channels (encrypted blob in S3/GitHub) were considered
+  and rejected: they need their own crypto, conflict handling, and bootstrap
+  credentials on every device.
+- **Sync opt-in (decided):** A toggle in Settings, **default OFF**. No secret
+  leaves the Mac until the user enables it. The toggle must be enabled on each
+  Mac that wants to participate.
+- **Env file semantics (decided):** **One-time import** via an explicit
+  "Import from .env…" action in Settings. The Keychain remains the sole source
+  of truth afterwards; the app never reads the file at launch or in the
+  background. The file can be deleted after import.
+- **Conflict rule for import (decided):** **Env always wins.** One confirmation
+  dialog (listing found keys with masked values and a "replaces existing
+  values" warning), then every key present in the file overwrites the stored
+  value. Keys absent from the file are left untouched — import never clears
+  anything.
+- **Priority model (decided):** Manual edits and env imports are peers; the
+  most recent write wins, locally and across Macs (keychain sync is
+  last-writer-wins per item).
+- **Architecture (decided):** Centralize keychain access in one injected
+  `AppSecureStorage` wrapper (approach A). The four services currently owning
+  `static const FlutterSecureStorage` instances are refactored to use it.
+- **New dependency:** `file_selector` (native open dialog, sandbox-safe).
+  Env parsing is hand-rolled (~30 lines); `flutter_dotenv` is built for bundled
+  asset env files and is the wrong fit.
+- **Docs:** README gains sections for both features (user interjection:
+  README must be updated as part of this work).
+
+## Architecture
+
+### New: `AppSecureStorage` (`lib/src/common/storage/app_secure_storage.dart`)
+
+Single wrapper around `FlutterSecureStorage`, registered in the service
+locator. All keychain traffic goes through it.
+
+- API: `read(key)`, `write(key, value)`, `delete(key)`, `containsKey(key)` —
+  each applying `MacOsOptions(synchronizable: <current flag>)`.
+- Owns the registry of the five known credential keys (listed above) used by
+  sync migration.
+- `syncEnabled` getter + `setSyncEnabled(bool)` which runs the migration
+  described below.
+- The toggle state itself is stored as an **always-local** keychain entry
+  (`secrets_sync_enabled`, never synchronizable) — it cannot live in the synced
+  set (chicken-and-egg) and the app has no other local preference store.
+- Initialized (flag loaded) during async `setup()` in the service locator
+  before dependent services are constructed.
+
+### Refactor: storage injection
+
+`FlutterSecureSecretsStorage`, `AiSettingsService`, `BackupService`, and
+`GitHubCredentialsStorage` receive `AppSecureStorage` via constructor injection
+(wired in `service_locator.dart`) instead of owning static
+`FlutterSecureStorage` instances. No behavior change beyond the applied
+options.
+
+### New: `EnvImportService`
+
+1. `parse(String contents)` — hand-rolled parser: `KEY=VALUE` lines, optional
+   `export ` prefix, single/double quotes, `#` comments, CRLF tolerated.
+   Unrecognized or unparseable lines are ignored and counted, never a blocker
+   (an unrelated notarization `.env` simply reports its vars as ignored).
+   Returns the recognized keys/values plus the ignored count.
+2. `apply(result)` — writes **through the existing services**
+   (`CredentialsService.saveCredentials`, `AiSettingsService.setOpenAiApiKey` /
+   `setJinaApiKey`, `BackupService.saveConfiguration`,
+   `GitHubCredentialsStorage.saveConfig`/`saveToken` as needed), so auth
+   notifiers and listeners update live without a restart. S3/GitHub configs
+   merge via `copyWith` — a file containing only `AWS_SECRET_ACCESS_KEY`
+   updates just that field. When no GitHub config exists yet, import creates
+   one with a freshly generated `deviceId` (UUID); `isConfigured` is set only
+   when owner, repo, and token are all present. Returns a per-key
+   success/failure summary.
+
+### Recognized environment variables
+
+| Group | Variables |
+|---|---|
+| Pinboard | `PINBOARD_API_TOKEN` |
+| OpenAI / Jina | `OPENAI_API_KEY`, `JINA_API_KEY` |
+| S3 backup | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `S3_BUCKET`, `S3_FILE_PATH` |
+| GitHub notes | `GITHUB_PAT`, `GITHUB_OWNER`, `GITHUB_REPO`, `GITHUB_BRANCH`, `GITHUB_NOTES_PATH` |
+
+### UI (Settings)
+
+New "Credentials" section containing:
+
+- **iCloud sync toggle** with explainer copy: requires iCloud Keychain; must be
+  enabled on each Mac. Enabling shows a confirmation stating *"Where a synced
+  value already exists, it replaces this Mac's value."*
+- **"Import from .env…" button** → native open dialog (`file_selector`) →
+  confirmation dialog (found keys, masked values, overwrite warning) → import →
+  per-key result summary.
+
+## Sync semantics
+
+A keychain item is either **local-only** or **synchronizable**; the attribute
+is part of the item's identity and the app only queries the kind matching its
+own toggle. The two sets are disjoint.
+
+- **Toggle OFF (default):** app reads/writes local-only items. Synced items
+  delivered by iCloud from other Macs sit dormant and invisible. Local edits
+  never leave the Mac. No conflicts possible — worst case is intentional
+  divergence.
+- **Enabling sync (migration, per known key):**
+  - If a synced value already exists (from another Mac) → adopt it: **synced
+    set wins**. Consistent with the "env always wins" simplicity rule.
+  - Else if a local value exists → rewrite it as synchronizable.
+  - Local-only copies are deleted afterwards (safe: local deletes do not
+    propagate).
+- **Disabling sync (per known key):** copy the current synced value into a
+  local-only item (a working snapshot), then stop reading the synced set. The
+  synced originals are **left in iCloud untouched** — deleting a synchronizable
+  item propagates deletion to every Mac and would destroy other machines'
+  credentials. Disabling on one Mac never harms the others; the Mac drifts
+  independently until re-enabled (synced-wins applies again).
+- **Flag flip ordering:** the toggle state flips only after all keys migrate.
+  Migration is idempotent (read → write-new → delete-old), so partial failure
+  leaves the toggle unchanged and retry is safe.
+
+## Error handling
+
+- **iCloud Keychain disabled on the Mac:** synchronizable writes still succeed;
+  items simply don't leave the device until iCloud Keychain is enabled. Not
+  reliably detectable → handled by explainer copy, not detection logic.
+- **Migration failure:** toggle unflipped, error shown, retry safe (see above).
+- **Env import:** unparseable/unrecognized lines ignored and counted; per-key
+  write failures reported in the result summary; file read failure
+  (permissions) → error dialog.
+
+## Testing
+
+- **Parser unit tests:** quotes, `export` prefix, comments, CRLF, junk lines.
+- **`EnvImportService` tests:** variable→service mapping, S3/GitHub `copyWith`
+  merging, env-wins overwrite, absent-keys-untouched, per-key failure summary.
+- **`AppSecureStorage` migration matrix** against a fake `FlutterSecureStorage`
+  (following existing mocktail/in-memory-storage patterns): local→synced,
+  synced→local snapshot, both-exist→synced-wins, disable-does-not-delete-synced,
+  partial-failure-leaves-flag.
+- **Cross-Mac sync** is not CI-testable → manual smoke checklist in the PR.
+
+## Documentation
+
+README gains two sections: **"Sync credentials across Macs (iCloud)"** (how it
+works, per-Mac opt-in, iCloud Keychain requirement, disable semantics) and
+**"Import credentials from a .env file"** (variable table, one-time-import +
+env-wins priority rules, note that the file can be deleted after import).
+
+## Out of scope
+
+- iOS or non-Apple platforms; any custom sync backend.
+- Watching the env file for changes / re-import on change.
+- Per-key conflict UI for import or sync-enable (simplicity rule: env wins,
+  synced set wins).
+- Export of credentials to a file.

--- a/integration_test/glass_smoke_test.dart
+++ b/integration_test/glass_smoke_test.dart
@@ -85,13 +85,13 @@ class _GlassHarnessState extends State<_GlassHarness> {
 }
 
 Widget _app() => LiquidGlassWidgets.wrap(
-      theme: appGlassTheme(),
-      child: MaterialApp(
-        debugShowCheckedModeBanner: false,
-        theme: appLightTheme(),
-        home: const _GlassHarness(),
-      ),
-    );
+  theme: appGlassTheme(),
+  child: MaterialApp(
+    debugShowCheckedModeBanner: false,
+    theme: appLightTheme(),
+    home: const _GlassHarness(),
+  ),
+);
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/lib/src/ai/README.md
+++ b/lib/src/ai/README.md
@@ -112,7 +112,9 @@ Added to Settings Page (`lib/src/pages/settings_page.dart`):
 
 Registered in `service_locator.dart`:
 ```dart
-..registerLazySingleton<AiSettingsService>(() => AiSettingsService());
+..registerLazySingleton<AiSettingsService>(
+  () => AiSettingsService(storage: locator.get<AppSecureStorage>()),
+)
 ```
 
 ## Dependencies Added

--- a/lib/src/ai/ai_settings_service.dart
+++ b/lib/src/ai/ai_settings_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
 import 'package:pinboard_wizard/src/ai/ai_settings.dart';
 import 'package:pinboard_wizard/src/ai/openai/openai_service.dart';
 import 'package:pinboard_wizard/src/ai/web_scraping/jina_service.dart';
@@ -8,7 +8,8 @@ import 'package:pinboard_wizard/src/service_locator.dart';
 
 class AiSettingsService extends ChangeNotifier {
   static const String _aiSettingsKey = 'ai_settings';
-  static const FlutterSecureStorage _secureStorage = FlutterSecureStorage();
+
+  final AppSecureStorage _secureStorage;
 
   AiSettings _settings = const AiSettings();
 
@@ -19,13 +20,14 @@ class AiSettingsService extends ChangeNotifier {
   OpenAiSettings get openaiSettings => _settings.openai;
   WebScrapingSettings get webScrapingSettings => _settings.webScraping;
 
-  AiSettingsService() {
+  AiSettingsService({required AppSecureStorage storage})
+    : _secureStorage = storage {
     _loadSettings();
   }
 
   Future<void> _loadSettings() async {
     try {
-      final settingsJson = await _secureStorage.read(key: _aiSettingsKey);
+      final settingsJson = await _secureStorage.read(_aiSettingsKey);
       if (settingsJson != null && settingsJson.isNotEmpty) {
         final Map<String, dynamic> settingsMap = json.decode(settingsJson);
         _settings = AiSettings.fromJson(settingsMap);
@@ -40,7 +42,7 @@ class AiSettingsService extends ChangeNotifier {
   Future<void> _saveSettings() async {
     try {
       final settingsJson = json.encode(_settings.toJson());
-      await _secureStorage.write(key: _aiSettingsKey, value: settingsJson);
+      await _secureStorage.write(_aiSettingsKey, settingsJson);
     } catch (e) {
       throw AiSettingsException('Failed to save AI settings: $e');
     }
@@ -109,7 +111,7 @@ class AiSettingsService extends ChangeNotifier {
   Future<void> clearAllAiSettings() async {
     _settings = const AiSettings();
     try {
-      await _secureStorage.delete(key: _aiSettingsKey);
+      await _secureStorage.delete(_aiSettingsKey);
     } catch (e) {
       throw AiSettingsException('Failed to clear AI settings: $e');
     }

--- a/lib/src/ai/ai_settings_service.dart
+++ b/lib/src/ai/ai_settings_service.dart
@@ -1,13 +1,14 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/common/storage/credential_keys.dart';
 import 'package:pinboard_wizard/src/ai/ai_settings.dart';
 import 'package:pinboard_wizard/src/ai/openai/openai_service.dart';
 import 'package:pinboard_wizard/src/ai/web_scraping/jina_service.dart';
 import 'package:pinboard_wizard/src/service_locator.dart';
 
 class AiSettingsService extends ChangeNotifier {
-  static const String _aiSettingsKey = 'ai_settings';
+  static const String _aiSettingsKey = CredentialKeys.aiSettings;
 
   final AppSecureStorage _secureStorage;
 

--- a/lib/src/backup/backup_service.dart
+++ b/lib/src/backup/backup_service.dart
@@ -41,6 +41,10 @@ class BackupService extends ChangeNotifier {
   /// Load S3 configuration from secure storage
   Future<void> loadConfiguration() async {
     try {
+      // Clear any stale error from a prior operation so callers can rely on
+      // the post-load status reflecting THIS load.
+      _status = BackupStatus.idle;
+      _lastError = null;
       final configJson = await _secureStorage.read(_s3ConfigKey);
       if (configJson != null && configJson.isNotEmpty) {
         final Map<String, dynamic> configMap = json.decode(configJson);

--- a/lib/src/backup/backup_service.dart
+++ b/lib/src/backup/backup_service.dart
@@ -4,6 +4,7 @@ import 'package:aws_s3_upload_lite/aws_s3_upload_lite.dart';
 import 'package:aws_s3_upload_lite/enum/acl.dart';
 import 'package:flutter/foundation.dart';
 import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/common/storage/credential_keys.dart';
 import 'package:intl/intl.dart';
 import 'package:pinboard_wizard/src/backup/models/s3_config.dart';
 import 'package:pinboard_wizard/src/pinboard/pinboard_service.dart';
@@ -18,7 +19,7 @@ enum S3VerificationMethod {
 }
 
 class BackupService extends ChangeNotifier {
-  static const String _s3ConfigKey = 'backup_s3_config';
+  static const String _s3ConfigKey = CredentialKeys.backupS3Config;
 
   final AppSecureStorage _secureStorage;
 

--- a/lib/src/backup/backup_service.dart
+++ b/lib/src/backup/backup_service.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:aws_s3_upload_lite/aws_s3_upload_lite.dart';
 import 'package:aws_s3_upload_lite/enum/acl.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
 import 'package:intl/intl.dart';
 import 'package:pinboard_wizard/src/backup/models/s3_config.dart';
 import 'package:pinboard_wizard/src/pinboard/pinboard_service.dart';
@@ -19,7 +19,10 @@ enum S3VerificationMethod {
 
 class BackupService extends ChangeNotifier {
   static const String _s3ConfigKey = 'backup_s3_config';
-  static const FlutterSecureStorage _secureStorage = FlutterSecureStorage();
+
+  final AppSecureStorage _secureStorage;
+
+  BackupService({required AppSecureStorage storage}) : _secureStorage = storage;
 
   S3Config _s3Config = const S3Config();
   BackupStatus _status = BackupStatus.idle;
@@ -38,7 +41,7 @@ class BackupService extends ChangeNotifier {
   /// Load S3 configuration from secure storage
   Future<void> loadConfiguration() async {
     try {
-      final configJson = await _secureStorage.read(key: _s3ConfigKey);
+      final configJson = await _secureStorage.read(_s3ConfigKey);
       if (configJson != null && configJson.isNotEmpty) {
         final Map<String, dynamic> configMap = json.decode(configJson);
         _s3Config = S3Config.fromJson(configMap);
@@ -59,7 +62,7 @@ class BackupService extends ChangeNotifier {
       notifyListeners();
 
       final configJson = json.encode(config.toJson());
-      await _secureStorage.write(key: _s3ConfigKey, value: configJson);
+      await _secureStorage.write(_s3ConfigKey, configJson);
 
       _s3Config = config;
       _status = BackupStatus.idle;
@@ -279,7 +282,7 @@ class BackupService extends ChangeNotifier {
   /// Clear all stored configuration
   Future<void> clearConfiguration() async {
     try {
-      await _secureStorage.delete(key: _s3ConfigKey);
+      await _secureStorage.delete(_s3ConfigKey);
       _s3Config = const S3Config();
       _status = BackupStatus.idle;
       _lastError = null;

--- a/lib/src/backup/backup_service.dart
+++ b/lib/src/backup/backup_service.dart
@@ -51,6 +51,9 @@ class BackupService extends ChangeNotifier {
       if (kDebugMode) {
         print('Failed to load S3 configuration: $e');
       }
+      _status = BackupStatus.error;
+      _lastError = 'Failed to load configuration: $e';
+      notifyListeners();
     }
   }
 

--- a/lib/src/common/storage/app_secure_storage.dart
+++ b/lib/src/common/storage/app_secure_storage.dart
@@ -65,29 +65,32 @@ class AppSecureStorage {
 
   /// Enables or disables iCloud sync, migrating all [syncedKeys].
   ///
-  /// Enabling runs in two phases: first every local-only value missing from
-  /// the synced set is pushed up (an existing synced value from another Mac
-  /// wins), then — only after every write succeeded — the local copies are
-  /// deleted (safe: local deletes never propagate). The order matters: if a
-  /// write fails partway through, no local copy has been deleted yet, so
-  /// there is no window where a migrated credential is invisible in both
-  /// sets.
+  /// Enabling is ordered around a single commit point:
   ///
-  /// Disabling: synced values are snapshotted into local-only items. The
-  /// synchronizable originals are LEFT UNTOUCHED — deleting a synchronizable
-  /// item propagates the deletion to every other Mac.
+  /// 1. Every local-only value missing from the synced set is pushed up (an
+  ///    existing synced value from another Mac wins).
+  /// 2. COMMIT POINT: the sync flag is persisted and [syncEnabled] flips.
+  ///    Any failure up to and including this write throws, leaves the flag
+  ///    off and every local copy intact — the migration is idempotent, so
+  ///    retry is safe.
+  /// 3. The migrated local copies are deleted as best-effort cleanup. The
+  ///    flag and the synced set are already consistent, so a failure here is
+  ///    only logged, never thrown: a leftover local copy is dormant (all
+  ///    reads and writes now target the synced set) and local deletes never
+  ///    propagate.
   ///
-  /// The flag flips only after every key migrates; the migration is
-  /// idempotent, so a partial failure leaves the toggle unchanged and retry
-  /// is safe.
+  /// Disabling: synced values are snapshotted into local-only items, then
+  /// the flag is persisted. The synchronizable originals are LEFT UNTOUCHED
+  /// — deleting a synchronizable item propagates the deletion to every
+  /// other Mac.
   Future<void> setSyncEnabled(bool enabled) async {
     if (enabled == _syncEnabled) {
       return;
     }
+    final localKeys = <String>[];
     try {
       if (enabled) {
         // Phase 1: push every local-only value missing from the synced set.
-        final localKeys = <String>[];
         for (final key in syncedKeys) {
           final local = await _storage.read(key: key, mOptions: _localOptions);
           if (local == null) {
@@ -106,10 +109,6 @@ class AppSecureStorage {
             );
           }
         }
-        // Phase 2: delete local copies only now that every write succeeded.
-        for (final key in localKeys) {
-          await _storage.delete(key: key, mOptions: _localOptions);
-        }
       } else {
         for (final key in syncedKeys) {
           final synced = await _storage.read(
@@ -125,6 +124,7 @@ class AppSecureStorage {
           }
         }
       }
+      // Commit point: nothing before this line changed observable state.
       await _storage.write(
         key: syncFlagKey,
         value: enabled ? 'true' : 'false',
@@ -135,6 +135,20 @@ class AppSecureStorage {
       throw AppSecureStorageException(
         'Failed to ${enabled ? 'enable' : 'disable'} credential sync: $e',
       );
+    }
+    if (enabled) {
+      // Phase 2: best-effort cleanup of the migrated local copies. The
+      // enable already committed, so a failure here must not throw.
+      try {
+        for (final key in localKeys) {
+          await _storage.delete(key: key, mOptions: _localOptions);
+        }
+      } catch (e) {
+        debugPrint(
+          'AppSecureStorage: failed to delete local copies after enabling '
+          'sync (leftover copies are dormant): $e',
+        );
+      }
     }
   }
 }

--- a/lib/src/common/storage/app_secure_storage.dart
+++ b/lib/src/common/storage/app_secure_storage.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:pinboard_wizard/src/common/storage/credential_keys.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 /// Central keychain access for all credential storage.
@@ -14,11 +15,11 @@ class AppSecureStorage {
   /// Every keychain key that participates in iCloud sync migration.
   /// Add new credential keys here when introducing new secret types.
   static const List<String> syncedKeys = [
-    'pinboard_credentials',
-    'ai_settings',
-    'backup_s3_config',
-    'github_notes_config',
-    'github_pat_token',
+    CredentialKeys.pinboardCredentials,
+    CredentialKeys.aiSettings,
+    CredentialKeys.backupS3Config,
+    CredentialKeys.githubNotesConfig,
+    CredentialKeys.githubPatToken,
   ];
 
   static const MacOsOptions _localOptions = MacOsOptions();

--- a/lib/src/common/storage/app_secure_storage.dart
+++ b/lib/src/common/storage/app_secure_storage.dart
@@ -27,8 +27,7 @@ class AppSecureStorage {
   final FlutterSecureStorage _storage;
   bool _syncEnabled = false;
 
-  AppSecureStorage({FlutterSecureStorage storage = const FlutterSecureStorage()})
-    : _storage = storage;
+  AppSecureStorage({this._storage = const FlutterSecureStorage()});
 
   /// Whether credentials are read from / written to the iCloud-synced set.
   bool get syncEnabled => _syncEnabled;
@@ -39,7 +38,10 @@ class AppSecureStorage {
   /// any dependent service reads credentials.
   Future<void> init() async {
     try {
-      final value = await _storage.read(key: syncFlagKey, mOptions: _localOptions);
+      final value = await _storage.read(
+        key: syncFlagKey,
+        mOptions: _localOptions,
+      );
       _syncEnabled = value == 'true';
     } catch (e) {
       debugPrint(
@@ -49,12 +51,14 @@ class AppSecureStorage {
     }
   }
 
-  Future<String?> read(String key) => _storage.read(key: key, mOptions: _current);
+  Future<String?> read(String key) =>
+      _storage.read(key: key, mOptions: _current);
 
   Future<void> write(String key, String value) =>
       _storage.write(key: key, value: value, mOptions: _current);
 
-  Future<void> delete(String key) => _storage.delete(key: key, mOptions: _current);
+  Future<void> delete(String key) =>
+      _storage.delete(key: key, mOptions: _current);
 
   Future<bool> containsKey(String key) =>
       _storage.containsKey(key: key, mOptions: _current);
@@ -79,10 +83,17 @@ class AppSecureStorage {
     try {
       if (enabled) {
         for (final key in syncedKeys) {
-          final synced = await _storage.read(key: key, mOptions: _syncedOptions);
+          final synced = await _storage.read(
+            key: key,
+            mOptions: _syncedOptions,
+          );
           final local = await _storage.read(key: key, mOptions: _localOptions);
           if (synced == null && local != null) {
-            await _storage.write(key: key, value: local, mOptions: _syncedOptions);
+            await _storage.write(
+              key: key,
+              value: local,
+              mOptions: _syncedOptions,
+            );
           }
           if (local != null) {
             await _storage.delete(key: key, mOptions: _localOptions);
@@ -90,9 +101,16 @@ class AppSecureStorage {
         }
       } else {
         for (final key in syncedKeys) {
-          final synced = await _storage.read(key: key, mOptions: _syncedOptions);
+          final synced = await _storage.read(
+            key: key,
+            mOptions: _syncedOptions,
+          );
           if (synced != null) {
-            await _storage.write(key: key, value: synced, mOptions: _localOptions);
+            await _storage.write(
+              key: key,
+              value: synced,
+              mOptions: _localOptions,
+            );
           }
         }
       }

--- a/lib/src/common/storage/app_secure_storage.dart
+++ b/lib/src/common/storage/app_secure_storage.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 /// Central keychain access for all credential storage.
@@ -40,7 +41,10 @@ class AppSecureStorage {
     try {
       final value = await _storage.read(key: syncFlagKey, mOptions: _localOptions);
       _syncEnabled = value == 'true';
-    } catch (_) {
+    } catch (e) {
+      debugPrint(
+        'AppSecureStorage: failed to read sync flag, defaulting to local-only: $e',
+      );
       _syncEnabled = false;
     }
   }

--- a/lib/src/common/storage/app_secure_storage.dart
+++ b/lib/src/common/storage/app_secure_storage.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// Central keychain access for all credential storage.
+///
+/// Owns the macOS keychain `synchronizable` attribute (iCloud Keychain sync).
+/// A keychain item is either local-only or synchronizable — the attribute is
+/// part of the item's identity, so all reads and writes must agree on it.
+/// This class is the single place that decides which set is active.
+class AppSecureStorage {
+  /// Local-only flag key. NEVER synchronizable (chicken-and-egg).
+  static const String syncFlagKey = 'secrets_sync_enabled';
+
+  /// Every keychain key that participates in iCloud sync migration.
+  /// Add new credential keys here when introducing new secret types.
+  static const List<String> syncedKeys = [
+    'pinboard_credentials',
+    'ai_settings',
+    'backup_s3_config',
+    'github_notes_config',
+    'github_pat_token',
+  ];
+
+  static const MacOsOptions _localOptions = MacOsOptions();
+  static const MacOsOptions _syncedOptions = MacOsOptions(synchronizable: true);
+
+  final FlutterSecureStorage _storage;
+  bool _syncEnabled = false;
+
+  AppSecureStorage({FlutterSecureStorage storage = const FlutterSecureStorage()})
+    : _storage = storage;
+
+  /// Whether credentials are read from / written to the iCloud-synced set.
+  bool get syncEnabled => _syncEnabled;
+
+  MacOsOptions get _current => _syncEnabled ? _syncedOptions : _localOptions;
+
+  /// Loads the persisted sync flag. Must be awaited during app setup before
+  /// any dependent service reads credentials.
+  Future<void> init() async {
+    try {
+      final value = await _storage.read(key: syncFlagKey, mOptions: _localOptions);
+      _syncEnabled = value == 'true';
+    } catch (_) {
+      _syncEnabled = false;
+    }
+  }
+
+  Future<String?> read(String key) => _storage.read(key: key, mOptions: _current);
+
+  Future<void> write(String key, String value) =>
+      _storage.write(key: key, value: value, mOptions: _current);
+
+  Future<void> delete(String key) => _storage.delete(key: key, mOptions: _current);
+
+  Future<bool> containsKey(String key) =>
+      _storage.containsKey(key: key, mOptions: _current);
+
+  /// Enables or disables iCloud sync, migrating all [syncedKeys].
+  ///
+  /// Enabling: an existing synced value (from another Mac) wins over the
+  /// local one; otherwise the local value is pushed up. Local-only copies are
+  /// deleted afterwards (safe: local deletes never propagate).
+  ///
+  /// Disabling: synced values are snapshotted into local-only items. The
+  /// synchronizable originals are LEFT UNTOUCHED — deleting a synchronizable
+  /// item propagates the deletion to every other Mac.
+  ///
+  /// The flag flips only after every key migrates; the migration is
+  /// idempotent, so a partial failure leaves the toggle unchanged and retry
+  /// is safe.
+  Future<void> setSyncEnabled(bool enabled) async {
+    if (enabled == _syncEnabled) {
+      return;
+    }
+    try {
+      if (enabled) {
+        for (final key in syncedKeys) {
+          final synced = await _storage.read(key: key, mOptions: _syncedOptions);
+          final local = await _storage.read(key: key, mOptions: _localOptions);
+          if (synced == null && local != null) {
+            await _storage.write(key: key, value: local, mOptions: _syncedOptions);
+          }
+          if (local != null) {
+            await _storage.delete(key: key, mOptions: _localOptions);
+          }
+        }
+      } else {
+        for (final key in syncedKeys) {
+          final synced = await _storage.read(key: key, mOptions: _syncedOptions);
+          if (synced != null) {
+            await _storage.write(key: key, value: synced, mOptions: _localOptions);
+          }
+        }
+      }
+      await _storage.write(
+        key: syncFlagKey,
+        value: enabled ? 'true' : 'false',
+        mOptions: _localOptions,
+      );
+      _syncEnabled = enabled;
+    } catch (e) {
+      throw AppSecureStorageException(
+        'Failed to ${enabled ? 'enable' : 'disable'} credential sync: $e',
+      );
+    }
+  }
+}
+
+class AppSecureStorageException implements Exception {
+  final String message;
+
+  const AppSecureStorageException(this.message);
+
+  @override
+  String toString() => 'AppSecureStorageException: $message';
+}

--- a/lib/src/common/storage/app_secure_storage.dart
+++ b/lib/src/common/storage/app_secure_storage.dart
@@ -65,9 +65,13 @@ class AppSecureStorage {
 
   /// Enables or disables iCloud sync, migrating all [syncedKeys].
   ///
-  /// Enabling: an existing synced value (from another Mac) wins over the
-  /// local one; otherwise the local value is pushed up. Local-only copies are
-  /// deleted afterwards (safe: local deletes never propagate).
+  /// Enabling runs in two phases: first every local-only value missing from
+  /// the synced set is pushed up (an existing synced value from another Mac
+  /// wins), then — only after every write succeeded — the local copies are
+  /// deleted (safe: local deletes never propagate). The order matters: if a
+  /// write fails partway through, no local copy has been deleted yet, so
+  /// there is no window where a migrated credential is invisible in both
+  /// sets.
   ///
   /// Disabling: synced values are snapshotted into local-only items. The
   /// synchronizable originals are LEFT UNTOUCHED — deleting a synchronizable
@@ -82,22 +86,29 @@ class AppSecureStorage {
     }
     try {
       if (enabled) {
+        // Phase 1: push every local-only value missing from the synced set.
+        final localKeys = <String>[];
         for (final key in syncedKeys) {
+          final local = await _storage.read(key: key, mOptions: _localOptions);
+          if (local == null) {
+            continue;
+          }
+          localKeys.add(key);
           final synced = await _storage.read(
             key: key,
             mOptions: _syncedOptions,
           );
-          final local = await _storage.read(key: key, mOptions: _localOptions);
-          if (synced == null && local != null) {
+          if (synced == null) {
             await _storage.write(
               key: key,
               value: local,
               mOptions: _syncedOptions,
             );
           }
-          if (local != null) {
-            await _storage.delete(key: key, mOptions: _localOptions);
-          }
+        }
+        // Phase 2: delete local copies only now that every write succeeded.
+        for (final key in localKeys) {
+          await _storage.delete(key: key, mOptions: _localOptions);
         }
       } else {
         for (final key in syncedKeys) {

--- a/lib/src/common/storage/credential_keys.dart
+++ b/lib/src/common/storage/credential_keys.dart
@@ -1,0 +1,13 @@
+/// Canonical keychain key for every stored credential.
+///
+/// Single source of truth referenced both by `AppSecureStorage.syncedKeys`
+/// and by each service's storage key, so the sync migration list can never
+/// drift from the keys services actually write. Deliberately imports
+/// nothing, making it safe to import from anywhere without cycles.
+abstract final class CredentialKeys {
+  static const String pinboardCredentials = 'pinboard_credentials';
+  static const String aiSettings = 'ai_settings';
+  static const String backupS3Config = 'backup_s3_config';
+  static const String githubNotesConfig = 'github_notes_config';
+  static const String githubPatToken = 'github_pat_token';
+}

--- a/lib/src/env_import/env_file_parser.dart
+++ b/lib/src/env_import/env_file_parser.dart
@@ -11,7 +11,9 @@ class ParsedEnvFile {
 
 /// Minimal `.env` parser: `KEY=VALUE` lines, optional `export ` prefix,
 /// surrounding single/double quotes stripped, `#` comment lines and blank
-/// lines skipped. Anything else is counted as ignored, never an error.
+/// lines skipped. In unquoted values an inline `#` preceded by whitespace
+/// starts a comment (dotenv convention); quoted values keep `#` intact.
+/// Anything else is counted as ignored, never an error.
 class EnvFileParser {
   static final RegExp _linePattern = RegExp(
     r'^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$',
@@ -33,18 +35,39 @@ class EnvFileParser {
         continue;
       }
 
-      variables[match.group(1)!] = _unquote(match.group(2)!.trim());
+      var value = match.group(2)!.trim();
+      if (!_isQuoteWrapped(value)) {
+        value = _stripInlineComment(value);
+      }
+      variables[match.group(1)!] = _unquote(value);
     }
 
     return ParsedEnvFile(variables: variables, ignoredLines: ignored);
   }
 
-  String _unquote(String value) {
-    if (value.length >= 2) {
-      final first = value[0];
-      final last = value[value.length - 1];
-      if ((first == '"' && last == '"') || (first == "'" && last == "'")) {
-        return value.substring(1, value.length - 1);
+  bool _isQuoteWrapped(String value) {
+    if (value.length < 2) {
+      return false;
+    }
+    final first = value[0];
+    final last = value[value.length - 1];
+    return (first == '"' && last == '"') || (first == "'" && last == "'");
+  }
+
+  String _unquote(String value) => _isQuoteWrapped(value)
+      ? value.substring(1, value.length - 1)
+      : value;
+
+  /// Cuts an unquoted value at the first `#` that follows whitespace:
+  /// `abc # comment` → `abc`, but `abc#def` is kept whole.
+  String _stripInlineComment(String value) {
+    for (var i = 1; i < value.length; i++) {
+      if (value[i] != '#') {
+        continue;
+      }
+      final previous = value[i - 1];
+      if (previous == ' ' || previous == '\t') {
+        return value.substring(0, i).trimRight();
       }
     }
     return value;

--- a/lib/src/env_import/env_file_parser.dart
+++ b/lib/src/env_import/env_file_parser.dart
@@ -57,15 +57,15 @@ class EnvFileParser {
   String _unquote(String value) =>
       _isQuoteWrapped(value) ? value.substring(1, value.length - 1) : value;
 
-  /// Cuts an unquoted value at the first `#` that follows whitespace:
-  /// `abc # comment` → `abc`, but `abc#def` is kept whole.
+  /// Cuts an unquoted value at the first `#` that starts the value or
+  /// follows whitespace: `abc # comment` → `abc`, `# comment` → empty,
+  /// but `abc#def` is kept whole.
   String _stripInlineComment(String value) {
-    for (var i = 1; i < value.length; i++) {
+    for (var i = 0; i < value.length; i++) {
       if (value[i] != '#') {
         continue;
       }
-      final previous = value[i - 1];
-      if (previous == ' ' || previous == '\t') {
+      if (i == 0 || value[i - 1] == ' ' || value[i - 1] == '\t') {
         return value.substring(0, i).trimRight();
       }
     }

--- a/lib/src/env_import/env_file_parser.dart
+++ b/lib/src/env_import/env_file_parser.dart
@@ -1,0 +1,52 @@
+/// Result of parsing a `.env`-style file.
+class ParsedEnvFile {
+  /// Variable name → value (quotes stripped). Later duplicates win.
+  final Map<String, String> variables;
+
+  /// Number of non-empty, non-comment lines that could not be parsed.
+  final int ignoredLines;
+
+  const ParsedEnvFile({required this.variables, required this.ignoredLines});
+}
+
+/// Minimal `.env` parser: `KEY=VALUE` lines, optional `export ` prefix,
+/// surrounding single/double quotes stripped, `#` comment lines and blank
+/// lines skipped. Anything else is counted as ignored, never an error.
+class EnvFileParser {
+  static final RegExp _linePattern = RegExp(
+    r'^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$',
+  );
+
+  ParsedEnvFile parse(String contents) {
+    final variables = <String, String>{};
+    var ignored = 0;
+
+    for (final rawLine in contents.split(RegExp(r'\r?\n'))) {
+      final line = rawLine.trim();
+      if (line.isEmpty || line.startsWith('#')) {
+        continue;
+      }
+
+      final match = _linePattern.firstMatch(line);
+      if (match == null) {
+        ignored++;
+        continue;
+      }
+
+      variables[match.group(1)!] = _unquote(match.group(2)!.trim());
+    }
+
+    return ParsedEnvFile(variables: variables, ignoredLines: ignored);
+  }
+
+  String _unquote(String value) {
+    if (value.length >= 2) {
+      final first = value[0];
+      final last = value[value.length - 1];
+      if ((first == '"' && last == '"') || (first == "'" && last == "'")) {
+        return value.substring(1, value.length - 1);
+      }
+    }
+    return value;
+  }
+}

--- a/lib/src/env_import/env_file_parser.dart
+++ b/lib/src/env_import/env_file_parser.dart
@@ -54,9 +54,8 @@ class EnvFileParser {
     return (first == '"' && last == '"') || (first == "'" && last == "'");
   }
 
-  String _unquote(String value) => _isQuoteWrapped(value)
-      ? value.substring(1, value.length - 1)
-      : value;
+  String _unquote(String value) =>
+      _isQuoteWrapped(value) ? value.substring(1, value.length - 1) : value;
 
   /// Cuts an unquoted value at the first `#` that follows whitespace:
   /// `abc # comment` → `abc`, but `abc#def` is kept whole.

--- a/lib/src/env_import/env_import_service.dart
+++ b/lib/src/env_import/env_import_service.dart
@@ -158,7 +158,17 @@ class EnvImportService {
           filePath: variables['S3_FILE_PATH'],
         );
         await _backupService.saveConfiguration(merged);
-        applied.addAll(s3Keys);
+        // saveConfiguration swallows storage errors into status/lastError
+        // instead of throwing, so check the status explicitly.
+        if (_backupService.status == BackupStatus.error) {
+          final message =
+              _backupService.lastError ?? 'Failed to save S3 configuration';
+          for (final key in s3Keys) {
+            failed[key] = message;
+          }
+        } else {
+          applied.addAll(s3Keys);
+        }
       } catch (e) {
         for (final key in s3Keys) {
           failed[key] = '$e';

--- a/lib/src/env_import/env_import_service.dart
+++ b/lib/src/env_import/env_import_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
 import 'package:pinboard_wizard/src/backup/backup_service.dart';
 import 'package:pinboard_wizard/src/env_import/env_file_parser.dart';
@@ -90,18 +91,23 @@ class EnvImportService {
     final parsed = _parser.parse(contents);
     final recognized = <String, String>{};
     final unrecognized = <String>[];
+    var emptyValueLines = 0;
 
     for (final entry in parsed.variables.entries) {
-      if (recognizedVariables.contains(entry.key)) {
-        recognized[entry.key] = entry.value;
-      } else {
+      if (!recognizedVariables.contains(entry.key)) {
         unrecognized.add(entry.key);
+      } else if (entry.value.isEmpty) {
+        // An empty value would clear a stored credential on import; treat
+        // the line as ignored instead so imports never erase secrets.
+        emptyValueLines++;
+      } else {
+        recognized[entry.key] = entry.value;
       }
     }
 
     return EnvImportPreview(
       recognized: recognized,
-      ignoredLines: parsed.ignoredLines,
+      ignoredLines: parsed.ignoredLines + emptyValueLines,
       unrecognized: unrecognized,
     );
   }
@@ -146,24 +152,36 @@ class EnvImportService {
     if (s3Keys.isNotEmpty) {
       try {
         await _backupService.loadConfiguration();
-        final merged = _backupService.s3Config.copyWith(
-          accessKey: variables['AWS_ACCESS_KEY_ID'],
-          secretKey: variables['AWS_SECRET_ACCESS_KEY'],
-          region: variables['AWS_REGION'],
-          bucketName: variables['S3_BUCKET'],
-          filePath: variables['S3_FILE_PATH'],
-        );
-        await _backupService.saveConfiguration(merged);
-        // saveConfiguration swallows storage errors into status/lastError
-        // instead of throwing, so check the status explicitly.
+        // loadConfiguration swallows storage errors into status/lastError;
+        // merging into a config that failed to load could clobber the real
+        // one, so skip the merge/save entirely when the load failed.
         if (_backupService.status == BackupStatus.error) {
           final message =
-              _backupService.lastError ?? 'Failed to save S3 configuration';
+              _backupService.lastError ??
+              'Failed to load existing S3 configuration';
           for (final key in s3Keys) {
             failed[key] = message;
           }
         } else {
-          applied.addAll(s3Keys);
+          final merged = _backupService.s3Config.copyWith(
+            accessKey: variables['AWS_ACCESS_KEY_ID'],
+            secretKey: variables['AWS_SECRET_ACCESS_KEY'],
+            region: variables['AWS_REGION'],
+            bucketName: variables['S3_BUCKET'],
+            filePath: variables['S3_FILE_PATH'],
+          );
+          await _backupService.saveConfiguration(merged);
+          // saveConfiguration swallows storage errors into status/lastError
+          // instead of throwing, so check the status explicitly.
+          if (_backupService.status == BackupStatus.error) {
+            final message =
+                _backupService.lastError ?? 'Failed to save S3 configuration';
+            for (final key in s3Keys) {
+              failed[key] = message;
+            }
+          } else {
+            applied.addAll(s3Keys);
+          }
         }
       } catch (e) {
         for (final key in s3Keys) {
@@ -175,10 +193,14 @@ class EnvImportService {
     // GitHub — merge into the existing config, or create one.
     final githubKeys = variables.keys.where(_githubVariables.contains).toList();
     if (githubKeys.isNotEmpty) {
+      final configKeys = githubKeys
+          .where((key) => key != 'GITHUB_PAT')
+          .toList();
+      final importedToken = variables['GITHUB_PAT'];
+
       try {
         final existing = await _githubStorage.readConfig();
-        final token =
-            variables['GITHUB_PAT'] ?? await _githubStorage.readToken();
+        final token = importedToken ?? await _githubStorage.readToken();
 
         final base =
             existing ??
@@ -197,16 +219,28 @@ class EnvImportService {
         );
 
         await _githubStorage.saveConfig(merged);
-        final importedToken = variables['GITHUB_PAT'];
-        if (importedToken != null) {
-          await _githubStorage.saveToken(importedToken);
-        }
-        await _githubAuthService.initialize();
-        applied.addAll(githubKeys);
+        applied.addAll(configKeys);
       } catch (e) {
-        for (final key in githubKeys) {
+        for (final key in configKeys) {
           failed[key] = '$e';
         }
+      }
+
+      if (importedToken != null) {
+        try {
+          await _githubStorage.saveToken(importedToken);
+          applied.add('GITHUB_PAT');
+        } catch (e) {
+          failed['GITHUB_PAT'] = '$e';
+        }
+      }
+
+      // Refresh auth state; a failure here is not an import failure — the
+      // credentials were already persisted above.
+      try {
+        await _githubAuthService.initialize();
+      } catch (e) {
+        debugPrint('EnvImportService: GitHub auth refresh failed: $e');
       }
     }
 

--- a/lib/src/env_import/env_import_service.dart
+++ b/lib/src/env_import/env_import_service.dart
@@ -204,9 +204,25 @@ class EnvImportService {
           .toList();
       final importedToken = variables['GITHUB_PAT'];
 
+      // Write the token BEFORE the config: isConfigured is derived from the
+      // token that is actually persisted, so a failed token write must not
+      // leave a saved config claiming to be configured without one.
+      var tokenPersisted = false;
+      if (importedToken != null) {
+        try {
+          await _githubStorage.saveToken(importedToken);
+          applied.add('GITHUB_PAT');
+          tokenPersisted = true;
+        } catch (e) {
+          failed['GITHUB_PAT'] = '$e';
+        }
+      }
+
       try {
         final existing = await _githubStorage.readConfig();
-        final token = importedToken ?? await _githubStorage.readToken();
+        final token = tokenPersisted
+            ? importedToken
+            : await _githubStorage.readToken();
 
         final base =
             existing ??
@@ -229,15 +245,6 @@ class EnvImportService {
       } catch (e) {
         for (final key in configKeys) {
           failed[key] = '$e';
-        }
-      }
-
-      if (importedToken != null) {
-        try {
-          await _githubStorage.saveToken(importedToken);
-          applied.add('GITHUB_PAT');
-        } catch (e) {
-          failed['GITHUB_PAT'] = '$e';
         }
       }
 

--- a/lib/src/env_import/env_import_service.dart
+++ b/lib/src/env_import/env_import_service.dart
@@ -79,16 +79,12 @@ class EnvImportService {
   final Uuid _uuid = const Uuid();
 
   EnvImportService({
-    required CredentialsService credentialsService,
-    required AiSettingsService aiSettingsService,
-    required BackupService backupService,
-    required GitHubCredentialsStorage githubStorage,
-    required GitHubAuthService githubAuthService,
-  }) : _credentialsService = credentialsService,
-       _aiSettingsService = aiSettingsService,
-       _backupService = backupService,
-       _githubStorage = githubStorage,
-       _githubAuthService = githubAuthService;
+    required this._credentialsService,
+    required this._aiSettingsService,
+    required this._backupService,
+    required this._githubStorage,
+    required this._githubAuthService,
+  });
 
   EnvImportPreview preview(String contents) {
     final parsed = _parser.parse(contents);
@@ -181,14 +177,12 @@ class EnvImportService {
     if (githubKeys.isNotEmpty) {
       try {
         final existing = await _githubStorage.readConfig();
-        final token = variables['GITHUB_PAT'] ?? await _githubStorage.readToken();
+        final token =
+            variables['GITHUB_PAT'] ?? await _githubStorage.readToken();
 
-        final base = existing ??
-            GitHubNotesConfig(
-              owner: '',
-              repo: '',
-              deviceId: _uuid.v4(),
-            );
+        final base =
+            existing ??
+            GitHubNotesConfig(owner: '', repo: '', deviceId: _uuid.v4());
         final owner = variables['GITHUB_OWNER'] ?? base.owner;
         final repo = variables['GITHUB_REPO'] ?? base.repo;
         final merged = base.copyWith(
@@ -197,7 +191,9 @@ class EnvImportService {
           branch: variables['GITHUB_BRANCH'] ?? base.branch,
           notesPath: variables['GITHUB_NOTES_PATH'] ?? base.notesPath,
           isConfigured:
-              owner.isNotEmpty && repo.isNotEmpty && (token?.isNotEmpty ?? false),
+              owner.isNotEmpty &&
+              repo.isNotEmpty &&
+              (token?.isNotEmpty ?? false),
         );
 
         await _githubStorage.saveConfig(merged);

--- a/lib/src/env_import/env_import_service.dart
+++ b/lib/src/env_import/env_import_service.dart
@@ -1,0 +1,209 @@
+import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
+import 'package:pinboard_wizard/src/backup/backup_service.dart';
+import 'package:pinboard_wizard/src/env_import/env_file_parser.dart';
+import 'package:pinboard_wizard/src/github/github_auth_service.dart';
+import 'package:pinboard_wizard/src/github/github_credentials_storage.dart';
+import 'package:pinboard_wizard/src/github/models/github_notes_config.dart';
+import 'package:pinboard_wizard/src/pinboard/credentials_service.dart';
+import 'package:uuid/uuid.dart';
+
+/// Preview of a parsed `.env` file, split into variables the app understands
+/// and everything else.
+class EnvImportPreview {
+  final Map<String, String> recognized;
+  final int ignoredLines;
+  final List<String> unrecognized;
+
+  const EnvImportPreview({
+    required this.recognized,
+    required this.ignoredLines,
+    required this.unrecognized,
+  });
+
+  bool get isEmpty => recognized.isEmpty;
+}
+
+/// Outcome of applying an import: which variables were written, and which
+/// failed with what message.
+class EnvImportResult {
+  final List<String> applied;
+  final Map<String, String> failed;
+
+  const EnvImportResult({required this.applied, required this.failed});
+}
+
+/// One-time import of credentials from `.env` file contents.
+///
+/// Env values always win over stored values; variables absent from the file
+/// are never touched. Writes go through the existing services so listeners
+/// (auth state, settings UI) update immediately.
+class EnvImportService {
+  static const Set<String> recognizedVariables = {
+    'PINBOARD_API_TOKEN',
+    'OPENAI_API_KEY',
+    'JINA_API_KEY',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_REGION',
+    'S3_BUCKET',
+    'S3_FILE_PATH',
+    'GITHUB_PAT',
+    'GITHUB_OWNER',
+    'GITHUB_REPO',
+    'GITHUB_BRANCH',
+    'GITHUB_NOTES_PATH',
+  };
+
+  static const _s3Variables = {
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_REGION',
+    'S3_BUCKET',
+    'S3_FILE_PATH',
+  };
+
+  static const _githubVariables = {
+    'GITHUB_PAT',
+    'GITHUB_OWNER',
+    'GITHUB_REPO',
+    'GITHUB_BRANCH',
+    'GITHUB_NOTES_PATH',
+  };
+
+  final CredentialsService _credentialsService;
+  final AiSettingsService _aiSettingsService;
+  final BackupService _backupService;
+  final GitHubCredentialsStorage _githubStorage;
+  final GitHubAuthService _githubAuthService;
+  final EnvFileParser _parser = EnvFileParser();
+  final Uuid _uuid = const Uuid();
+
+  EnvImportService({
+    required CredentialsService credentialsService,
+    required AiSettingsService aiSettingsService,
+    required BackupService backupService,
+    required GitHubCredentialsStorage githubStorage,
+    required GitHubAuthService githubAuthService,
+  }) : _credentialsService = credentialsService,
+       _aiSettingsService = aiSettingsService,
+       _backupService = backupService,
+       _githubStorage = githubStorage,
+       _githubAuthService = githubAuthService;
+
+  EnvImportPreview preview(String contents) {
+    final parsed = _parser.parse(contents);
+    final recognized = <String, String>{};
+    final unrecognized = <String>[];
+
+    for (final entry in parsed.variables.entries) {
+      if (recognizedVariables.contains(entry.key)) {
+        recognized[entry.key] = entry.value;
+      } else {
+        unrecognized.add(entry.key);
+      }
+    }
+
+    return EnvImportPreview(
+      recognized: recognized,
+      ignoredLines: parsed.ignoredLines,
+      unrecognized: unrecognized,
+    );
+  }
+
+  Future<EnvImportResult> apply(Map<String, String> variables) async {
+    final applied = <String>[];
+    final failed = <String, String>{};
+
+    // Pinboard
+    final pinboardToken = variables['PINBOARD_API_TOKEN'];
+    if (pinboardToken != null) {
+      try {
+        await _credentialsService.saveCredentials(pinboardToken);
+        applied.add('PINBOARD_API_TOKEN');
+      } catch (e) {
+        failed['PINBOARD_API_TOKEN'] = '$e';
+      }
+    }
+
+    // OpenAI / Jina
+    final openAiKey = variables['OPENAI_API_KEY'];
+    if (openAiKey != null) {
+      try {
+        await _aiSettingsService.setOpenAiApiKey(openAiKey);
+        applied.add('OPENAI_API_KEY');
+      } catch (e) {
+        failed['OPENAI_API_KEY'] = '$e';
+      }
+    }
+    final jinaKey = variables['JINA_API_KEY'];
+    if (jinaKey != null) {
+      try {
+        await _aiSettingsService.setJinaApiKey(jinaKey);
+        applied.add('JINA_API_KEY');
+      } catch (e) {
+        failed['JINA_API_KEY'] = '$e';
+      }
+    }
+
+    // S3 backup — merge into the existing config.
+    final s3Keys = variables.keys.where(_s3Variables.contains).toList();
+    if (s3Keys.isNotEmpty) {
+      try {
+        await _backupService.loadConfiguration();
+        final merged = _backupService.s3Config.copyWith(
+          accessKey: variables['AWS_ACCESS_KEY_ID'],
+          secretKey: variables['AWS_SECRET_ACCESS_KEY'],
+          region: variables['AWS_REGION'],
+          bucketName: variables['S3_BUCKET'],
+          filePath: variables['S3_FILE_PATH'],
+        );
+        await _backupService.saveConfiguration(merged);
+        applied.addAll(s3Keys);
+      } catch (e) {
+        for (final key in s3Keys) {
+          failed[key] = '$e';
+        }
+      }
+    }
+
+    // GitHub — merge into the existing config, or create one.
+    final githubKeys = variables.keys.where(_githubVariables.contains).toList();
+    if (githubKeys.isNotEmpty) {
+      try {
+        final existing = await _githubStorage.readConfig();
+        final token = variables['GITHUB_PAT'] ?? await _githubStorage.readToken();
+
+        final base = existing ??
+            GitHubNotesConfig(
+              owner: '',
+              repo: '',
+              deviceId: _uuid.v4(),
+            );
+        final owner = variables['GITHUB_OWNER'] ?? base.owner;
+        final repo = variables['GITHUB_REPO'] ?? base.repo;
+        final merged = base.copyWith(
+          owner: owner,
+          repo: repo,
+          branch: variables['GITHUB_BRANCH'] ?? base.branch,
+          notesPath: variables['GITHUB_NOTES_PATH'] ?? base.notesPath,
+          isConfigured:
+              owner.isNotEmpty && repo.isNotEmpty && (token?.isNotEmpty ?? false),
+        );
+
+        await _githubStorage.saveConfig(merged);
+        final importedToken = variables['GITHUB_PAT'];
+        if (importedToken != null) {
+          await _githubStorage.saveToken(importedToken);
+        }
+        await _githubAuthService.initialize();
+        applied.addAll(githubKeys);
+      } catch (e) {
+        for (final key in githubKeys) {
+          failed[key] = '$e';
+        }
+      }
+    }
+
+    return EnvImportResult(applied: applied, failed: failed);
+  }
+}

--- a/lib/src/env_import/env_import_service.dart
+++ b/lib/src/env_import/env_import_service.dart
@@ -116,14 +116,20 @@ class EnvImportService {
     final applied = <String>[];
     final failed = <String, String>{};
 
-    // Pinboard
+    // Pinboard — reject malformed tokens up front; a save would otherwise
+    // persist a credential that can never authenticate.
     final pinboardToken = variables['PINBOARD_API_TOKEN'];
     if (pinboardToken != null) {
-      try {
-        await _credentialsService.saveCredentials(pinboardToken);
-        applied.add('PINBOARD_API_TOKEN');
-      } catch (e) {
-        failed['PINBOARD_API_TOKEN'] = '$e';
+      if (!_credentialsService.isValidApiKey(pinboardToken)) {
+        failed['PINBOARD_API_TOKEN'] =
+            'Invalid Pinboard token format (expected username:hexstring)';
+      } else {
+        try {
+          await _credentialsService.saveCredentials(pinboardToken);
+          applied.add('PINBOARD_API_TOKEN');
+        } catch (e) {
+          failed['PINBOARD_API_TOKEN'] = '$e';
+        }
       }
     }
 

--- a/lib/src/github/README.md
+++ b/lib/src/github/README.md
@@ -347,7 +347,9 @@ class ValidationResult {
 ### 1. Initialize Auth Service
 
 ```dart
-final authService = GitHubAuthService();
+final authService = GitHubAuthService(
+  storage: getIt<GitHubCredentialsStorage>(),
+);
 await authService.initialize();
 
 // Listen to auth state changes
@@ -528,7 +530,7 @@ void setupServiceLocator() {
   // ... existing services
 
   getIt.registerLazySingleton<GitHubCredentialsStorage>(
-    () => GitHubCredentialsStorage(),
+    () => GitHubCredentialsStorage(storage: getIt<AppSecureStorage>()),
   );
 
   getIt.registerLazySingleton<GitHubAuthService>(
@@ -744,7 +746,7 @@ void setupServiceLocator() {
 
   // Storage
   getIt.registerLazySingleton<GitHubCredentialsStorage>(
-    () => GitHubCredentialsStorage(),
+    () => GitHubCredentialsStorage(storage: getIt<AppSecureStorage>()),
   );
 
   // Auth service

--- a/lib/src/github/github_auth_service.dart
+++ b/lib/src/github/github_auth_service.dart
@@ -10,8 +10,7 @@ class GitHubAuthService extends ChangeNotifier {
   TokenExpiryWarning? _currentWarning;
   bool _isAuthenticated = false;
 
-  GitHubAuthService({required GitHubCredentialsStorage storage})
-    : _storage = storage;
+  GitHubAuthService({required this._storage});
 
   /// Current token expiry warning, if any
   TokenExpiryWarning? get currentWarning => _currentWarning;

--- a/lib/src/github/github_auth_service.dart
+++ b/lib/src/github/github_auth_service.dart
@@ -10,8 +10,8 @@ class GitHubAuthService extends ChangeNotifier {
   TokenExpiryWarning? _currentWarning;
   bool _isAuthenticated = false;
 
-  GitHubAuthService({GitHubCredentialsStorage? storage})
-    : _storage = storage ?? GitHubCredentialsStorage();
+  GitHubAuthService({required GitHubCredentialsStorage storage})
+    : _storage = storage;
 
   /// Current token expiry warning, if any
   TokenExpiryWarning? get currentWarning => _currentWarning;

--- a/lib/src/github/github_credentials_storage.dart
+++ b/lib/src/github/github_credentials_storage.dart
@@ -1,12 +1,13 @@
 import 'dart:convert';
 
 import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/common/storage/credential_keys.dart';
 import 'package:pinboard_wizard/src/github/models/github_notes_config.dart';
 
 /// Service for securely storing and retrieving GitHub credentials and configuration
 class GitHubCredentialsStorage {
-  static const String _configKey = 'github_notes_config';
-  static const String _tokenKey = 'github_pat_token';
+  static const String _configKey = CredentialKeys.githubNotesConfig;
+  static const String _tokenKey = CredentialKeys.githubPatToken;
 
   final AppSecureStorage _secureStorage;
 

--- a/lib/src/github/github_credentials_storage.dart
+++ b/lib/src/github/github_credentials_storage.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
 import 'package:pinboard_wizard/src/github/models/github_notes_config.dart';
 
 /// Service for securely storing and retrieving GitHub credentials and configuration
@@ -8,14 +8,17 @@ class GitHubCredentialsStorage {
   static const String _configKey = 'github_notes_config';
   static const String _tokenKey = 'github_pat_token';
 
-  static const FlutterSecureStorage _secureStorage = FlutterSecureStorage();
+  final AppSecureStorage _secureStorage;
+
+  GitHubCredentialsStorage({required AppSecureStorage storage})
+    : _secureStorage = storage;
 
   /// Read the GitHub notes configuration (without token)
   ///
   /// Applies migration: converts legacy default 'notes/' to empty string
   Future<GitHubNotesConfig?> readConfig() async {
     try {
-      final configJson = await _secureStorage.read(key: _configKey);
+      final configJson = await _secureStorage.read(_configKey);
 
       if (configJson == null || configJson.isEmpty) {
         return null;
@@ -33,7 +36,7 @@ class GitHubCredentialsStorage {
   /// Read the Personal Access Token
   Future<String?> readToken() async {
     try {
-      return await _secureStorage.read(key: _tokenKey);
+      return await _secureStorage.read(_tokenKey);
     } catch (e) {
       return null;
     }
@@ -43,7 +46,7 @@ class GitHubCredentialsStorage {
   Future<void> saveConfig(GitHubNotesConfig config) async {
     try {
       final configJson = json.encode(config.toJson());
-      await _secureStorage.write(key: _configKey, value: configJson);
+      await _secureStorage.write(_configKey, configJson);
     } catch (e) {
       throw GitHubStorageException('Failed to save configuration: $e');
     }
@@ -52,7 +55,7 @@ class GitHubCredentialsStorage {
   /// Save the Personal Access Token
   Future<void> saveToken(String token) async {
     try {
-      await _secureStorage.write(key: _tokenKey, value: token);
+      await _secureStorage.write(_tokenKey, token);
     } catch (e) {
       throw GitHubStorageException('Failed to save token: $e');
     }
@@ -88,7 +91,7 @@ class GitHubCredentialsStorage {
   /// Clear the GitHub notes configuration
   Future<void> clearConfig() async {
     try {
-      await _secureStorage.delete(key: _configKey);
+      await _secureStorage.delete(_configKey);
     } catch (e) {
       throw GitHubStorageException('Failed to clear configuration: $e');
     }
@@ -97,7 +100,7 @@ class GitHubCredentialsStorage {
   /// Clear the Personal Access Token
   Future<void> clearToken() async {
     try {
-      await _secureStorage.delete(key: _tokenKey);
+      await _secureStorage.delete(_tokenKey);
     } catch (e) {
       throw GitHubStorageException('Failed to clear token: $e');
     }

--- a/lib/src/pages/bookmarks/add_bookmark_dialog.dart
+++ b/lib/src/pages/bookmarks/add_bookmark_dialog.dart
@@ -95,10 +95,7 @@ class _AddBookmarkDialogState extends State<AddBookmarkDialog> {
                     ),
                   ),
                   const SizedBox(width: 12),
-                  Text(
-                    'Add Bookmark',
-                    style: context.appTypography.largeTitle,
-                  ),
+                  Text('Add Bookmark', style: context.appTypography.largeTitle),
                   const Spacer(),
                   AppIconButton(
                     icon: const Icon(CupertinoIcons.xmark),
@@ -300,10 +297,7 @@ class _AddBookmarkDialogState extends State<AddBookmarkDialog> {
                 Expanded(
                   child: Text(
                     _aiError!,
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: AppColors.systemRed,
-                    ),
+                    style: TextStyle(fontSize: 12, color: AppColors.systemRed),
                   ),
                 ),
               ],

--- a/lib/src/pages/bookmarks/bookmarks_page.dart
+++ b/lib/src/pages/bookmarks/bookmarks_page.dart
@@ -368,10 +368,7 @@ class _BookmarksPageState extends State<BookmarksPage> {
       return const Center(
         child: Text(
           'No bookmarks found',
-          style: TextStyle(
-            color: AppColors.secondaryLabel,
-            fontSize: 13,
-          ),
+          style: TextStyle(color: AppColors.secondaryLabel, fontSize: 13),
         ),
       );
     }
@@ -418,9 +415,7 @@ class _BookmarksPageState extends State<BookmarksPage> {
     return Container(
       decoration: BoxDecoration(
         color: context.canvasColor,
-        border: Border(
-          top: BorderSide(color: AppColors.separator, width: 0.5),
-        ),
+        border: Border(top: BorderSide(color: AppColors.separator, width: 0.5)),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Row(

--- a/lib/src/pages/bookmarks/edit_bookmark_dialog.dart
+++ b/lib/src/pages/bookmarks/edit_bookmark_dialog.dart
@@ -289,10 +289,7 @@ class _EditBookmarkDialogState extends State<EditBookmarkDialog> {
                 Expanded(
                   child: Text(
                     _aiError!,
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: AppColors.systemRed,
-                    ),
+                    style: TextStyle(fontSize: 12, color: AppColors.systemRed),
                   ),
                 ),
               ],

--- a/lib/src/pages/bookmarks/pin_category_dialog.dart
+++ b/lib/src/pages/bookmarks/pin_category_dialog.dart
@@ -116,14 +116,10 @@ class _PinCategoryDialogState extends State<PinCategoryDialog> {
                           vertical: 2,
                         ),
                         decoration: BoxDecoration(
-                          color: AppColors.accent.withValues(
-                            alpha: 0.1,
-                          ),
+                          color: AppColors.accent.withValues(alpha: 0.1),
                           borderRadius: BorderRadius.circular(6),
                           border: Border.all(
-                            color: AppColors.accent.withValues(
-                              alpha: 0.3,
-                            ),
+                            color: AppColors.accent.withValues(alpha: 0.3),
                             width: 0.5,
                           ),
                         ),

--- a/lib/src/pages/bookmarks/resizable_split_view.dart
+++ b/lib/src/pages/bookmarks/resizable_split_view.dart
@@ -104,9 +104,7 @@ class _ResizableSplitViewState extends State<ResizableSplitView> {
                 ? AppColors.accent.withValues(alpha: 0.3)
                 : AppColors.separator,
           ),
-          child: Center(
-            child: Container(width: 1, color: AppColors.separator),
-          ),
+          child: Center(child: Container(width: 1, color: AppColors.separator)),
         ),
       ),
     );

--- a/lib/src/pages/bookmarks/tags_panel.dart
+++ b/lib/src/pages/bookmarks/tags_panel.dart
@@ -82,10 +82,7 @@ class TagsPanel extends StatelessWidget {
           padding: EdgeInsets.all(16),
           child: Text(
             'No tags available',
-            style: TextStyle(
-              color: AppColors.secondaryLabel,
-              fontSize: 13,
-            ),
+            style: TextStyle(color: AppColors.secondaryLabel, fontSize: 13),
           ),
         ),
       );
@@ -120,9 +117,7 @@ class TagsPanel extends StatelessWidget {
                     : AppColors.controlBackground),
           borderRadius: BorderRadius.circular(12),
           border: Border.all(
-            color: isSelected
-                ? AppColors.accent
-                : AppColors.separator,
+            color: isSelected ? AppColors.accent : AppColors.separator,
             width: 0.5,
           ),
         ),
@@ -159,9 +154,7 @@ class TagsPanel extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        border: Border(
-          top: BorderSide(color: AppColors.separator, width: 0.5),
-        ),
+        border: Border(top: BorderSide(color: AppColors.separator, width: 0.5)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/src/pages/notes/github_notes_page.dart
+++ b/lib/src/pages/notes/github_notes_page.dart
@@ -252,11 +252,7 @@ class _GitHubNotesPageState extends State<GitHubNotesPage> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(
-              CupertinoIcons.doc_text,
-              size: 64,
-              color: Colors.grey,
-            ),
+            const Icon(CupertinoIcons.doc_text, size: 64, color: Colors.grey),
             const SizedBox(height: 16),
             const Text(
               'No notes yet',
@@ -439,11 +435,7 @@ class _GitHubNotesPageState extends State<GitHubNotesPage> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(
-              CupertinoIcons.search,
-              size: 48,
-              color: Colors.grey,
-            ),
+            const Icon(CupertinoIcons.search, size: 48, color: Colors.grey),
             const SizedBox(height: 16),
             Text(
               'No notes found',
@@ -510,9 +502,7 @@ class _GitHubNotesPageState extends State<GitHubNotesPage> {
               'Select a note to view',
               style: TextStyle(
                 fontSize: 16,
-                color: isDark
-                    ? Colors.white60
-                    : AppColors.secondaryLabel,
+                color: isDark ? Colors.white60 : AppColors.secondaryLabel,
               ),
             ),
           ],
@@ -780,9 +770,7 @@ class _GitHubNotesPageState extends State<GitHubNotesPage> {
     return Container(
       decoration: BoxDecoration(
         color: AppColors.canvas.resolveFrom(context),
-        border: Border(
-          top: BorderSide(color: AppColors.separator, width: 0.5),
-        ),
+        border: Border(top: BorderSide(color: AppColors.separator, width: 0.5)),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Row(

--- a/lib/src/pages/notes/resizable_split_view.dart
+++ b/lib/src/pages/notes/resizable_split_view.dart
@@ -104,9 +104,7 @@ class _ResizableSplitViewState extends State<ResizableSplitView> {
                 ? AppColors.accent.withValues(alpha: 0.3)
                 : AppColors.separator,
           ),
-          child: Center(
-            child: Container(width: 1, color: AppColors.separator),
-          ),
+          child: Center(child: Container(width: 1, color: AppColors.separator)),
         ),
       ),
     );

--- a/lib/src/pages/notes/widgets/new_note_form.dart
+++ b/lib/src/pages/notes/widgets/new_note_form.dart
@@ -86,10 +86,7 @@ class _NewNoteFormState extends State<NewNoteForm> {
                 color: isDark ? Colors.white70 : Colors.black87,
               ),
               const SizedBox(width: 12),
-              Text(
-                'Create New Note',
-                style: context.appTypography.title2,
-              ),
+              Text('Create New Note', style: context.appTypography.title2),
             ],
           ),
           const SizedBox(height: 24),
@@ -107,10 +104,7 @@ class _NewNoteFormState extends State<NewNoteForm> {
           const SizedBox(height: 24),
 
           // Content field
-          Text(
-            'Content (Optional)',
-            style: context.appTypography.headline,
-          ),
+          Text('Content (Optional)', style: context.appTypography.headline),
           const SizedBox(height: 8),
           Text(
             'You can leave this empty and add content after creation',

--- a/lib/src/pages/pinned/pinned_page.dart
+++ b/lib/src/pages/pinned/pinned_page.dart
@@ -72,11 +72,7 @@ class _PinnedPageState extends State<PinnedPage> {
         children: [
           Row(
             children: [
-              Icon(
-                CupertinoIcons.pin_fill,
-                size: 24,
-                color: AppColors.accent,
-              ),
+              Icon(CupertinoIcons.pin_fill, size: 24, color: AppColors.accent),
               const SizedBox(width: 12),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -86,8 +82,7 @@ class _PinnedPageState extends State<PinnedPage> {
                     style: TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.w600,
-                      color:
-                          context.appBrightness == Brightness.dark
+                      color: context.appBrightness == Brightness.dark
                           ? Colors.white
                           : Colors.black,
                     ),
@@ -96,9 +91,7 @@ class _PinnedPageState extends State<PinnedPage> {
                     'Quick access to your favorite links',
                     style: TextStyle(
                       fontSize: 13,
-                      color: AppColors.secondaryLabel.resolveFrom(
-                        context,
-                      ),
+                      color: AppColors.secondaryLabel.resolveFrom(context),
                     ),
                   ),
                 ],
@@ -246,9 +239,7 @@ class _PinnedPageState extends State<PinnedPage> {
     return Container(
       decoration: BoxDecoration(
         color: AppColors.canvas.resolveFrom(context),
-        border: Border(
-          top: BorderSide(color: AppColors.separator, width: 0.5),
-        ),
+        border: Border(top: BorderSide(color: AppColors.separator, width: 0.5)),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Row(
@@ -350,11 +341,7 @@ class _PinnedPageState extends State<PinnedPage> {
       padding: const EdgeInsets.fromLTRB(16, 18, 16, 8),
       child: Row(
         children: [
-          Icon(
-            _getCategoryIcon(categoryName),
-            size: 13,
-            color: color,
-          ),
+          Icon(_getCategoryIcon(categoryName), size: 13, color: color),
           const SizedBox(width: 6),
           Text(
             categoryName.toUpperCase(),

--- a/lib/src/pages/pinned/state/pinned_cubit.dart
+++ b/lib/src/pages/pinned/state/pinned_cubit.dart
@@ -4,8 +4,7 @@ import 'package:pinboard_wizard/src/pinboard/models/post.dart';
 import 'package:pinboard_wizard/src/pinboard/pinboard_service.dart';
 
 class PinnedCubit extends Cubit<PinnedState> {
-  PinnedCubit({required this._pinboardService})
-    : super(const PinnedState());
+  PinnedCubit({required this._pinboardService}) : super(const PinnedState());
 
   final PinboardService _pinboardService;
 

--- a/lib/src/pages/settings/settings_page.dart
+++ b/lib/src/pages/settings/settings_page.dart
@@ -1447,7 +1447,22 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
           ),
           if (state.envImportMessage != null) ...[
             const SizedBox(height: 12),
-            Text(state.envImportMessage!, style: context.appTypography.body),
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    state.envImportMessage!,
+                    style: context.appTypography.body,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                AppIconButton(
+                  icon: const Icon(CupertinoIcons.xmark, size: 14),
+                  onPressed: () =>
+                      context.read<SettingsCubit>().clearEnvImportMessage(),
+                ),
+              ],
+            ),
           ],
         ],
       ),

--- a/lib/src/pages/settings/settings_page.dart
+++ b/lib/src/pages/settings/settings_page.dart
@@ -9,6 +9,7 @@ import 'package:pinboard_wizard/src/backup/backup_service.dart';
 import 'package:pinboard_wizard/src/backup/models/s3_config.dart';
 import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
 import 'package:pinboard_wizard/src/common/widgets/app_logo.dart';
+import 'package:pinboard_wizard/src/common/widgets/dialogs.dart';
 import 'package:pinboard_wizard/src/common/widgets/validated_secret_field.dart';
 import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
 import 'package:pinboard_wizard/src/github/github_auth_service.dart';
@@ -1475,27 +1476,13 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
       await cubit.setSecretsSyncEnabled(false);
       return;
     }
-    final confirmed = await showAppAlertDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AppAlertDialog(
-        title: const Text('Enable iCloud sync?'),
-        message: const Text(
-          'Your credentials will sync across Macs signed into the same '
-          'iCloud account. Where a synced value already exists, it replaces '
-          'this Mac\'s value.',
-        ),
-        primaryButton: AppButton(
-          size: AppButtonSize.large,
-          onPressed: () => Navigator.of(dialogContext).pop(true),
-          child: const Text('Enable'),
-        ),
-        secondaryButton: AppButton(
-          size: AppButtonSize.large,
-          secondary: true,
-          onPressed: () => Navigator.of(dialogContext).pop(false),
-          child: const Text('Cancel'),
-        ),
-      ),
+    final confirmed = await CommonDialogs.showConfirmation(
+      context,
+      'Your credentials will sync across Macs signed into the same '
+      'iCloud account. Where a synced value already exists, it replaces '
+      'this Mac\'s value.',
+      title: 'Enable iCloud sync?',
+      confirmText: 'Enable',
     );
     if (confirmed == true) {
       await cubit.setSecretsSyncEnabled(true);
@@ -1519,18 +1506,11 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
       contents = await file.readAsString();
     } catch (e) {
       if (!mounted) return;
-      await showAppAlertDialog<void>(
+      await CommonDialogs.showError(
         // ignore: use_build_context_synchronously
-        context: context,
-        builder: (dialogContext) => AppAlertDialog(
-          title: const Text('Could not read file'),
-          message: Text('$e'),
-          primaryButton: AppButton(
-            size: AppButtonSize.large,
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: const Text('OK'),
-          ),
-        ),
+        context,
+        '$e',
+        title: 'Could not read file',
       );
       return;
     }
@@ -1539,21 +1519,12 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
     if (!mounted) return;
 
     if (preview.isEmpty) {
-      await showAppAlertDialog<void>(
+      await CommonDialogs.showInfo(
         // ignore: use_build_context_synchronously
-        context: context,
-        builder: (dialogContext) => AppAlertDialog(
-          title: const Text('Nothing to import'),
-          message: Text(
-            'No recognized variables found.'
-            '${preview.unrecognized.isNotEmpty ? ' Unrecognized: ${preview.unrecognized.join(', ')}.' : ''}',
-          ),
-          primaryButton: AppButton(
-            size: AppButtonSize.large,
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: const Text('OK'),
-          ),
-        ),
+        context,
+        'No recognized variables found.'
+        '${preview.unrecognized.isNotEmpty ? ' Unrecognized: ${preview.unrecognized.join(', ')}.' : ''}',
+        title: 'Nothing to import',
       );
       return;
     }
@@ -1568,27 +1539,13 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
         '${preview.ignoredLines} unparseable line(s) ignored.',
     ].join(' ');
 
-    final confirmed = await showAppAlertDialog<bool>(
+    final confirmed = await CommonDialogs.showConfirmation(
       // ignore: use_build_context_synchronously
-      context: context,
-      builder: (dialogContext) => AppAlertDialog(
-        title: const Text('Import credentials?'),
-        message: Text(
-          'The following values will be imported and will REPLACE any '
-          'existing values:\n\n$lines${extra.isNotEmpty ? '\n\n$extra' : ''}',
-        ),
-        primaryButton: AppButton(
-          size: AppButtonSize.large,
-          onPressed: () => Navigator.of(dialogContext).pop(true),
-          child: const Text('Import'),
-        ),
-        secondaryButton: AppButton(
-          size: AppButtonSize.large,
-          secondary: true,
-          onPressed: () => Navigator.of(dialogContext).pop(false),
-          child: const Text('Cancel'),
-        ),
-      ),
+      context,
+      'The following values will be imported and will REPLACE any '
+      'existing values:\n\n$lines${extra.isNotEmpty ? '\n\n$extra' : ''}',
+      title: 'Import credentials?',
+      confirmText: 'Import',
     );
 
     if (confirmed == true) {

--- a/lib/src/pages/settings/settings_page.dart
+++ b/lib/src/pages/settings/settings_page.dart
@@ -6,8 +6,10 @@ import 'package:pinboard_wizard/src/ui/ui.dart';
 import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
 import 'package:pinboard_wizard/src/backup/backup_service.dart';
 import 'package:pinboard_wizard/src/backup/models/s3_config.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
 import 'package:pinboard_wizard/src/common/widgets/app_logo.dart';
 import 'package:pinboard_wizard/src/common/widgets/validated_secret_field.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
 import 'package:pinboard_wizard/src/github/github_auth_service.dart';
 import 'package:pinboard_wizard/src/github/models/models.dart';
 import 'package:pinboard_wizard/src/pages/settings/state/settings_cubit.dart';
@@ -29,6 +31,8 @@ class SettingsPage extends StatelessWidget {
         aiSettingsService: locator.get<AiSettingsService>(),
         backupService: locator.get<BackupService>(),
         githubAuthService: locator.get<GitHubAuthService>(),
+        appSecureStorage: locator.get<AppSecureStorage>(),
+        envImportService: locator.get<EnvImportService>(),
       )..loadSettings(),
       child: const _SettingsPageView(),
     );

--- a/lib/src/pages/settings/settings_page.dart
+++ b/lib/src/pages/settings/settings_page.dart
@@ -216,10 +216,7 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'Pinboard Configuration',
-            style: context.appTypography.title1,
-          ),
+          Text('Pinboard Configuration', style: context.appTypography.title1),
           const SizedBox(height: 12),
           Row(
             children: [
@@ -312,10 +309,7 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'AI Assistance',
-            style: context.appTypography.title1,
-          ),
+          Text('AI Assistance', style: context.appTypography.title1),
           const SizedBox(height: 12),
 
           // Enable AI Toggle
@@ -654,10 +648,7 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'Backup Configuration',
-            style: context.appTypography.title1,
-          ),
+          Text('Backup Configuration', style: context.appTypography.title1),
           const SizedBox(height: 12),
           Text(
             'Securely backup your bookmarks to Amazon S3. All credentials are encrypted and stored locally.',
@@ -668,10 +659,7 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
           // S3 Configuration Section
           Row(
             children: [
-              Text(
-                'Amazon S3 Settings',
-                style: context.appTypography.headline,
-              ),
+              Text('Amazon S3 Settings', style: context.appTypography.headline),
               const SizedBox(width: 8),
               AppIconButton(
                 icon: const Icon(CupertinoIcons.link, size: 14),
@@ -744,10 +732,7 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
           const SizedBox(height: 16),
 
           // File Path (optional)
-          Text(
-            'File Path (Optional)',
-            style: context.appTypography.body,
-          ),
+          Text('File Path (Optional)', style: context.appTypography.body),
           const SizedBox(height: 4),
           AppTextField(
             controller: _s3FilePathController,
@@ -913,10 +898,7 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
           const SizedBox(height: 32),
 
           // Backup Section
-          Text(
-            'Backup Operations',
-            style: context.appTypography.headline,
-          ),
+          Text('Backup Operations', style: context.appTypography.headline),
           const SizedBox(height: 8),
           Text(
             'Create a JSON backup of all your bookmarks including titles, descriptions, tags, and metadata.',
@@ -1100,16 +1082,10 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
           ],
 
           // Repository Configuration
-          Text(
-            'Repository Settings',
-            style: context.appTypography.headline,
-          ),
+          Text('Repository Settings', style: context.appTypography.headline),
           const SizedBox(height: 8),
 
-          Text(
-            'GitHub Owner/Organization',
-            style: context.appTypography.body,
-          ),
+          Text('GitHub Owner/Organization', style: context.appTypography.body),
           const SizedBox(height: 4),
           AppTextField(
             controller: _githubOwnerController,
@@ -1117,10 +1093,7 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
           ),
           const SizedBox(height: 12),
 
-          Text(
-            'Repository Name',
-            style: context.appTypography.body,
-          ),
+          Text('Repository Name', style: context.appTypography.body),
           const SizedBox(height: 4),
           AppTextField(
             controller: _githubRepoController,
@@ -1128,10 +1101,7 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
           ),
           const SizedBox(height: 12),
 
-          Text(
-            'Branch (Optional)',
-            style: context.appTypography.body,
-          ),
+          Text('Branch (Optional)', style: context.appTypography.body),
           const SizedBox(height: 4),
           AppTextField(
             controller: _githubBranchController,
@@ -1139,10 +1109,7 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
           ),
           const SizedBox(height: 12),
 
-          Text(
-            'Notes Path (Optional)',
-            style: context.appTypography.body,
-          ),
+          Text('Notes Path (Optional)', style: context.appTypography.body),
           const SizedBox(height: 8),
           AppTextField(
             controller: _githubNotesPathController,
@@ -1333,10 +1300,7 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
           // Help Section
           Container(height: 1, color: AppColors.separator),
           const SizedBox(height: 16),
-          Text(
-            'Setup Instructions',
-            style: context.appTypography.headline,
-          ),
+          Text('Setup Instructions', style: context.appTypography.headline),
           const SizedBox(height: 8),
           Text(
             '1. Create a private repository on GitHub for your notes\n'

--- a/lib/src/pages/settings/settings_page.dart
+++ b/lib/src/pages/settings/settings_page.dart
@@ -1517,7 +1517,7 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
   }
 
   String _maskSecret(String value) {
-    if (value.length <= 8) return '••••';
+    if (value.length <= 12) return '••••';
     return '${value.substring(0, 4)}…${value.substring(value.length - 4)}';
   }
 
@@ -1559,8 +1559,8 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
         builder: (dialogContext) => AppAlertDialog(
           title: const Text('Nothing to import'),
           message: Text(
-            'No recognized variables found. '
-            '${preview.unrecognized.isNotEmpty ? 'Unrecognized: ${preview.unrecognized.join(', ')}.' : ''}',
+            'No recognized variables found.'
+            '${preview.unrecognized.isNotEmpty ? ' Unrecognized: ${preview.unrecognized.join(', ')}.' : ''}',
           ),
           primaryButton: AppButton(
             size: AppButtonSize.large,

--- a/lib/src/pages/settings/settings_page.dart
+++ b/lib/src/pages/settings/settings_page.dart
@@ -1420,6 +1420,13 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
               ),
             ],
           ),
+          if (state.syncErrorMessage != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              state.syncErrorMessage!,
+              style: const TextStyle(color: AppColors.systemRed),
+            ),
+          ],
           const SizedBox(height: 24),
           Container(height: 1, color: AppColors.separator),
           const SizedBox(height: 16),

--- a/lib/src/pages/settings/settings_page.dart
+++ b/lib/src/pages/settings/settings_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:file_selector/file_selector.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pinboard_wizard/src/ui/ui.dart';
@@ -70,7 +71,7 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
   @override
   void initState() {
     super.initState();
-    _tabController = AppTabController(length: 4);
+    _tabController = AppTabController(length: 5);
     _apiKeyController.addListener(_onApiKeyChanged);
     _openaiKeyController.addListener(_onOpenAiKeyChanged);
     _jinaKeyController.addListener(_onJinaKeyChanged);
@@ -191,12 +192,14 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
                     AppTab(label: 'AI Settings'),
                     AppTab(label: 'Backups'),
                     AppTab(label: 'GitHub Notes'),
+                    AppTab(label: 'Sync'),
                   ],
                   children: [
                     _buildPinboardTab(context, state),
                     _buildAiTab(context, state),
                     _buildBackupTab(context, state),
                     _buildGitHubTab(context, state),
+                    _buildSyncTab(context, state),
                   ],
                 ),
               ),
@@ -1421,6 +1424,189 @@ class _SettingsPageViewState extends State<_SettingsPageView> {
     if (!await launchUrl(uri)) {
       // Handle error - could show a dialog or copy to clipboard as fallback
       debugPrint('Could not launch $url');
+    }
+  }
+
+  Widget _buildSyncTab(BuildContext context, SettingsState state) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('iCloud Sync', style: context.appTypography.headline),
+          const SizedBox(height: 8),
+          Text(
+            'Sync your Pinboard, AI, backup, and GitHub credentials across '
+            'your Macs using iCloud Keychain. Requires iCloud Keychain to be '
+            'enabled in System Settings, and must be switched on separately '
+            'on each Mac.',
+            style: context.appTypography.body,
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              AppSwitch(
+                value: state.secretsSyncEnabled,
+                onChanged: (value) => _onSyncToggleChanged(context, value),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                'Sync credentials across devices',
+                style: context.appTypography.body,
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Container(height: 1, color: AppColors.separator),
+          const SizedBox(height: 16),
+          Text('Import from .env', style: context.appTypography.headline),
+          const SizedBox(height: 8),
+          Text(
+            'Import credentials from a .env file instead of entering them '
+            'manually. Values in the file replace existing ones; anything '
+            'not in the file is left unchanged. The file is read once — you '
+            'can delete it afterwards.',
+            style: context.appTypography.body,
+          ),
+          const SizedBox(height: 12),
+          AppButton(
+            size: AppButtonSize.large,
+            onPressed: () => _importEnvFile(context),
+            child: const Text('Import from .env…'),
+          ),
+          if (state.envImportMessage != null) ...[
+            const SizedBox(height: 12),
+            Text(state.envImportMessage!, style: context.appTypography.body),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Future<void> _onSyncToggleChanged(BuildContext context, bool value) async {
+    final cubit = context.read<SettingsCubit>();
+    if (!value) {
+      await cubit.setSecretsSyncEnabled(false);
+      return;
+    }
+    final confirmed = await showAppAlertDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AppAlertDialog(
+        title: const Text('Enable iCloud sync?'),
+        message: const Text(
+          'Your credentials will sync across Macs signed into the same '
+          'iCloud account. Where a synced value already exists, it replaces '
+          'this Mac\'s value.',
+        ),
+        primaryButton: AppButton(
+          size: AppButtonSize.large,
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          child: const Text('Enable'),
+        ),
+        secondaryButton: AppButton(
+          size: AppButtonSize.large,
+          secondary: true,
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: const Text('Cancel'),
+        ),
+      ),
+    );
+    if (confirmed == true) {
+      await cubit.setSecretsSyncEnabled(true);
+    }
+  }
+
+  String _maskSecret(String value) {
+    if (value.length <= 8) return '••••';
+    return '${value.substring(0, 4)}…${value.substring(value.length - 4)}';
+  }
+
+  Future<void> _importEnvFile(BuildContext context) async {
+    final cubit = context.read<SettingsCubit>();
+    final file = await openFile(
+      acceptedTypeGroups: const [XTypeGroup(label: 'env files')],
+    );
+    if (file == null) return;
+
+    final String contents;
+    try {
+      contents = await file.readAsString();
+    } catch (e) {
+      if (!mounted) return;
+      await showAppAlertDialog<void>(
+        // ignore: use_build_context_synchronously
+        context: context,
+        builder: (dialogContext) => AppAlertDialog(
+          title: const Text('Could not read file'),
+          message: Text('$e'),
+          primaryButton: AppButton(
+            size: AppButtonSize.large,
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('OK'),
+          ),
+        ),
+      );
+      return;
+    }
+
+    final preview = cubit.previewEnvImport(contents);
+    if (!mounted) return;
+
+    if (preview.isEmpty) {
+      await showAppAlertDialog<void>(
+        // ignore: use_build_context_synchronously
+        context: context,
+        builder: (dialogContext) => AppAlertDialog(
+          title: const Text('Nothing to import'),
+          message: Text(
+            'No recognized variables found. '
+            '${preview.unrecognized.isNotEmpty ? 'Unrecognized: ${preview.unrecognized.join(', ')}.' : ''}',
+          ),
+          primaryButton: AppButton(
+            size: AppButtonSize.large,
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('OK'),
+          ),
+        ),
+      );
+      return;
+    }
+
+    final lines = preview.recognized.entries
+        .map((e) => '${e.key} = ${_maskSecret(e.value)}')
+        .join('\n');
+    final extra = <String>[
+      if (preview.unrecognized.isNotEmpty)
+        '${preview.unrecognized.length} unrecognized variable(s) ignored.',
+      if (preview.ignoredLines > 0)
+        '${preview.ignoredLines} unparseable line(s) ignored.',
+    ].join(' ');
+
+    final confirmed = await showAppAlertDialog<bool>(
+      // ignore: use_build_context_synchronously
+      context: context,
+      builder: (dialogContext) => AppAlertDialog(
+        title: const Text('Import credentials?'),
+        message: Text(
+          'The following values will be imported and will REPLACE any '
+          'existing values:\n\n$lines${extra.isNotEmpty ? '\n\n$extra' : ''}',
+        ),
+        primaryButton: AppButton(
+          size: AppButtonSize.large,
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          child: const Text('Import'),
+        ),
+        secondaryButton: AppButton(
+          size: AppButtonSize.large,
+          secondary: true,
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: const Text('Cancel'),
+        ),
+      ),
+    );
+
+    if (confirmed == true) {
+      await cubit.importEnvVariables(preview.recognized);
     }
   }
 }

--- a/lib/src/pages/settings/state/settings_cubit.dart
+++ b/lib/src/pages/settings/state/settings_cubit.dart
@@ -4,6 +4,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
 import 'package:pinboard_wizard/src/backup/backup_service.dart';
 import 'package:pinboard_wizard/src/backup/models/s3_config.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
 import 'package:pinboard_wizard/src/github/github_auth_service.dart';
 import 'package:pinboard_wizard/src/github/github_config_validator.dart';
 import 'package:pinboard_wizard/src/github/models/models.dart';
@@ -19,6 +21,8 @@ class SettingsCubit extends Cubit<SettingsState> {
     required this._aiSettingsService,
     required this._backupService,
     required this._githubAuthService,
+    required this._appSecureStorage,
+    required this._envImportService,
     GitHubConfigValidator? githubConfigValidator,
   }) : _githubConfigValidator =
            githubConfigValidator ?? GitHubConfigValidator(),
@@ -39,6 +43,8 @@ class SettingsCubit extends Cubit<SettingsState> {
   final BackupService _backupService;
   final GitHubAuthService _githubAuthService;
   final GitHubConfigValidator _githubConfigValidator;
+  final AppSecureStorage _appSecureStorage;
+  final EnvImportService _envImportService;
   Timer? _debounceTimer;
 
   /// Safely emit a state, checking if the cubit is not closed
@@ -88,6 +94,7 @@ class SettingsCubit extends Cubit<SettingsState> {
           githubToken: githubToken ?? '',
           isGitHubAuthenticated: _githubAuthService.isAuthenticated,
           tokenExpiryWarning: _githubAuthService.currentWarning,
+          secretsSyncEnabled: _appSecureStorage.syncEnabled,
         ),
       );
 
@@ -911,6 +918,39 @@ class SettingsCubit extends Cubit<SettingsState> {
         tokenExpiryWarning: _githubAuthService.currentWarning,
       ),
     );
+  }
+
+  /// Enable or disable iCloud Keychain sync for all credentials.
+  Future<void> setSecretsSyncEnabled(bool enabled) async {
+    try {
+      await _appSecureStorage.setSyncEnabled(enabled);
+      _safeEmit(
+        state.copyWith(secretsSyncEnabled: _appSecureStorage.syncEnabled),
+      );
+      // Reload so values adopted from the synced set appear in the UI.
+      await loadSettings();
+    } catch (e) {
+      _safeEmit(
+        state.copyWith(
+          errorMessage: 'Failed to ${enabled ? 'enable' : 'disable'} sync: $e',
+        ),
+      );
+    }
+  }
+
+  /// Parse .env contents into recognized/unrecognized variables.
+  EnvImportPreview previewEnvImport(String contents) =>
+      _envImportService.preview(contents);
+
+  /// Apply recognized env variables. Env values always win.
+  Future<void> importEnvVariables(Map<String, String> variables) async {
+    final result = await _envImportService.apply(variables);
+    final buffer = StringBuffer('Imported ${result.applied.length} value(s).');
+    if (result.failed.isNotEmpty) {
+      buffer.write(' Failed: ${result.failed.keys.join(', ')}.');
+    }
+    _safeEmit(state.copyWith(envImportMessage: buffer.toString()));
+    await loadSettings();
   }
 
   @override

--- a/lib/src/pages/settings/state/settings_cubit.dart
+++ b/lib/src/pages/settings/state/settings_cubit.dart
@@ -925,14 +925,18 @@ class SettingsCubit extends Cubit<SettingsState> {
     try {
       await _appSecureStorage.setSyncEnabled(enabled);
       _safeEmit(
-        state.copyWith(secretsSyncEnabled: _appSecureStorage.syncEnabled),
+        state.copyWith(
+          secretsSyncEnabled: _appSecureStorage.syncEnabled,
+          syncErrorMessage: null,
+        ),
       );
       // Reload so values adopted from the synced set appear in the UI.
       await loadSettings();
     } catch (e) {
       _safeEmit(
         state.copyWith(
-          errorMessage: 'Failed to ${enabled ? 'enable' : 'disable'} sync: $e',
+          syncErrorMessage:
+              'Failed to ${enabled ? 'enable' : 'disable'} sync: $e',
         ),
       );
     }

--- a/lib/src/pages/settings/state/settings_cubit.dart
+++ b/lib/src/pages/settings/state/settings_cubit.dart
@@ -948,6 +948,9 @@ class SettingsCubit extends Cubit<SettingsState> {
 
   /// Apply recognized env variables. Env values always win.
   Future<void> importEnvVariables(Map<String, String> variables) async {
+    // Clear any banner left over from a previous import so a stale summary
+    // never shows next to the new import's outcome.
+    _safeEmit(state.copyWith(envImportMessage: null));
     final result = await _envImportService.apply(variables);
     final buffer = StringBuffer('Imported ${result.applied.length} value(s).');
     if (result.failed.isNotEmpty) {
@@ -955,6 +958,11 @@ class SettingsCubit extends Cubit<SettingsState> {
     }
     _safeEmit(state.copyWith(envImportMessage: buffer.toString()));
     await loadSettings();
+  }
+
+  /// Dismiss the env import result banner.
+  void clearEnvImportMessage() {
+    _safeEmit(state.copyWith(envImportMessage: null));
   }
 
   @override

--- a/lib/src/pages/settings/state/settings_state.dart
+++ b/lib/src/pages/settings/state/settings_state.dart
@@ -40,6 +40,9 @@ class SettingsState extends Equatable {
     this.githubValidationStatus = ValidationStatus.initial,
     this.githubValidationMessage,
     this.tokenExpiryWarning,
+    // Credential sync & import
+    this.secretsSyncEnabled = false,
+    this.envImportMessage,
   });
 
   final SettingsStatus status;
@@ -78,6 +81,10 @@ class SettingsState extends Equatable {
   final String? githubValidationMessage;
   final TokenExpiryWarning? tokenExpiryWarning;
 
+  // Credential sync & import
+  final bool secretsSyncEnabled;
+  final String? envImportMessage;
+
   SettingsState copyWith({
     SettingsStatus? status,
     Object? errorMessage = _sentinel,
@@ -106,6 +113,8 @@ class SettingsState extends Equatable {
     ValidationStatus? githubValidationStatus,
     Object? githubValidationMessage = _sentinel,
     Object? tokenExpiryWarning = _sentinel,
+    bool? secretsSyncEnabled,
+    Object? envImportMessage = _sentinel,
   }) {
     return SettingsState(
       status: status ?? this.status,
@@ -159,6 +168,10 @@ class SettingsState extends Equatable {
       tokenExpiryWarning: tokenExpiryWarning == _sentinel
           ? this.tokenExpiryWarning
           : tokenExpiryWarning as TokenExpiryWarning?,
+      secretsSyncEnabled: secretsSyncEnabled ?? this.secretsSyncEnabled,
+      envImportMessage: envImportMessage == _sentinel
+          ? this.envImportMessage
+          : envImportMessage as String?,
     );
   }
 
@@ -231,5 +244,7 @@ class SettingsState extends Equatable {
     githubValidationStatus,
     githubValidationMessage,
     tokenExpiryWarning,
+    secretsSyncEnabled,
+    envImportMessage,
   ];
 }

--- a/lib/src/pages/settings/state/settings_state.dart
+++ b/lib/src/pages/settings/state/settings_state.dart
@@ -43,6 +43,7 @@ class SettingsState extends Equatable {
     // Credential sync & import
     this.secretsSyncEnabled = false,
     this.envImportMessage,
+    this.syncErrorMessage,
   });
 
   final SettingsStatus status;
@@ -84,6 +85,7 @@ class SettingsState extends Equatable {
   // Credential sync & import
   final bool secretsSyncEnabled;
   final String? envImportMessage;
+  final String? syncErrorMessage;
 
   SettingsState copyWith({
     SettingsStatus? status,
@@ -115,6 +117,7 @@ class SettingsState extends Equatable {
     Object? tokenExpiryWarning = _sentinel,
     bool? secretsSyncEnabled,
     Object? envImportMessage = _sentinel,
+    Object? syncErrorMessage = _sentinel,
   }) {
     return SettingsState(
       status: status ?? this.status,
@@ -172,6 +175,9 @@ class SettingsState extends Equatable {
       envImportMessage: envImportMessage == _sentinel
           ? this.envImportMessage
           : envImportMessage as String?,
+      syncErrorMessage: syncErrorMessage == _sentinel
+          ? this.syncErrorMessage
+          : syncErrorMessage as String?,
     );
   }
 
@@ -246,5 +252,6 @@ class SettingsState extends Equatable {
     tokenExpiryWarning,
     secretsSyncEnabled,
     envImportMessage,
+    syncErrorMessage,
   ];
 }

--- a/lib/src/pinboard/credentials_service.dart
+++ b/lib/src/pinboard/credentials_service.dart
@@ -8,8 +8,7 @@ class CredentialsService {
   // Emits true when a valid API key is present, false otherwise
   final ValueNotifier<bool> isAuthenticatedNotifier = ValueNotifier(false);
 
-  CredentialsService({SecretStorage? storage})
-    : _storage = storage ?? FlutterSecureSecretsStorage() {
+  CredentialsService({required SecretStorage storage}) : _storage = storage {
     _loadInitial();
   }
 

--- a/lib/src/pinboard/credentials_service.dart
+++ b/lib/src/pinboard/credentials_service.dart
@@ -8,7 +8,7 @@ class CredentialsService {
   // Emits true when a valid API key is present, false otherwise
   final ValueNotifier<bool> isAuthenticatedNotifier = ValueNotifier(false);
 
-  CredentialsService({required SecretStorage storage}) : _storage = storage {
+  CredentialsService({required this._storage}) {
     _loadInitial();
   }
 

--- a/lib/src/pinboard/flutter_secure_secrets_storage.dart
+++ b/lib/src/pinboard/flutter_secure_secrets_storage.dart
@@ -1,17 +1,20 @@
 import 'dart:convert';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
 import 'package:pinboard_wizard/src/pinboard/models/credentials.dart';
 import 'package:pinboard_wizard/src/pinboard/secrets_storage.dart';
 
 class FlutterSecureSecretsStorage implements SecretStorage {
   static const String _credentialsKey = 'pinboard_credentials';
 
-  static const FlutterSecureStorage _secureStorage = FlutterSecureStorage();
+  final AppSecureStorage _storage;
+
+  FlutterSecureSecretsStorage({required AppSecureStorage storage})
+    : _storage = storage;
 
   @override
   Future<Credentials?> read() async {
     try {
-      final credentialsJson = await _secureStorage.read(key: _credentialsKey);
+      final credentialsJson = await _storage.read(_credentialsKey);
 
       if (credentialsJson == null || credentialsJson.isEmpty) {
         return null;
@@ -30,7 +33,7 @@ class FlutterSecureSecretsStorage implements SecretStorage {
   Future<void> save(Credentials credentials) async {
     try {
       final credentialsJson = json.encode(credentials.toJson());
-      await _secureStorage.write(key: _credentialsKey, value: credentialsJson);
+      await _storage.write(_credentialsKey, credentialsJson);
     } catch (e) {
       throw SecureStorageException('Failed to save credentials: $e');
     }
@@ -39,7 +42,7 @@ class FlutterSecureSecretsStorage implements SecretStorage {
   @override
   Future<void> clear() async {
     try {
-      await _secureStorage.delete(key: _credentialsKey);
+      await _storage.delete(_credentialsKey);
     } catch (e) {
       throw SecureStorageException('Failed to clear credentials: $e');
     }
@@ -47,26 +50,10 @@ class FlutterSecureSecretsStorage implements SecretStorage {
 
   Future<bool> hasCredentials() async {
     try {
-      final credentialsJson = await _secureStorage.read(key: _credentialsKey);
+      final credentialsJson = await _storage.read(_credentialsKey);
       return credentialsJson != null && credentialsJson.isNotEmpty;
     } catch (e) {
       return false;
-    }
-  }
-
-  Future<void> clearAll() async {
-    try {
-      await _secureStorage.deleteAll();
-    } catch (e) {
-      throw SecureStorageException('Failed to clear all data: $e');
-    }
-  }
-
-  Future<Map<String, String>> readAll() async {
-    try {
-      return await _secureStorage.readAll();
-    } catch (e) {
-      return {};
     }
   }
 }

--- a/lib/src/pinboard/flutter_secure_secrets_storage.dart
+++ b/lib/src/pinboard/flutter_secure_secrets_storage.dart
@@ -8,8 +8,7 @@ class FlutterSecureSecretsStorage implements SecretStorage {
 
   final AppSecureStorage _storage;
 
-  FlutterSecureSecretsStorage({required AppSecureStorage storage})
-    : _storage = storage;
+  FlutterSecureSecretsStorage({required this._storage});
 
   @override
   Future<Credentials?> read() async {

--- a/lib/src/pinboard/flutter_secure_secrets_storage.dart
+++ b/lib/src/pinboard/flutter_secure_secrets_storage.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/common/storage/credential_keys.dart';
 import 'package:pinboard_wizard/src/pinboard/models/credentials.dart';
 import 'package:pinboard_wizard/src/pinboard/secrets_storage.dart';
 
 class FlutterSecureSecretsStorage implements SecretStorage {
-  static const String _credentialsKey = 'pinboard_credentials';
+  static const String _credentialsKey = CredentialKeys.pinboardCredentials;
 
   final AppSecureStorage _storage;
 

--- a/lib/src/pinboard/pinboard_client.dart
+++ b/lib/src/pinboard/pinboard_client.dart
@@ -38,10 +38,8 @@ class PinboardClient {
   final SecretStorage _secretStorage;
   final http.Client _httpClient;
 
-  PinboardClient({
-    required this._secretStorage,
-    http.Client? httpClient,
-  }) : _httpClient = httpClient ?? http.Client();
+  PinboardClient({required this._secretStorage, http.Client? httpClient})
+    : _httpClient = httpClient ?? http.Client();
   Future<Credentials?> _getCredentials() async {
     try {
       return await _secretStorage.read();

--- a/lib/src/service_locator.dart
+++ b/lib/src/service_locator.dart
@@ -42,9 +42,8 @@ Future<void> setup() async {
       () => CredentialsService(storage: locator.get<SecretStorage>()),
     )
     ..registerLazySingleton<SecretStorage>(
-      () => FlutterSecureSecretsStorage(
-        storage: locator.get<AppSecureStorage>(),
-      ),
+      () =>
+          FlutterSecureSecretsStorage(storage: locator.get<AppSecureStorage>()),
     )
     ..registerLazySingleton<AiSettingsService>(
       () => AiSettingsService(storage: locator.get<AppSecureStorage>()),

--- a/lib/src/service_locator.dart
+++ b/lib/src/service_locator.dart
@@ -7,6 +7,7 @@ import 'package:pinboard_wizard/src/ai/web_scraping/jina_service.dart';
 import 'package:pinboard_wizard/src/backup/backup_service.dart';
 import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
 import 'package:pinboard_wizard/src/database/notes_database.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
 import 'package:pinboard_wizard/src/github/github_auth_service.dart';
 import 'package:pinboard_wizard/src/github/github_client.dart';
 import 'package:pinboard_wizard/src/github/github_config_validator.dart';
@@ -62,6 +63,15 @@ Future<void> setup() async {
     )
     ..registerLazySingleton<GitHubConfigValidator>(
       () => GitHubConfigValidator(),
+    )
+    ..registerLazySingleton<EnvImportService>(
+      () => EnvImportService(
+        credentialsService: locator.get<CredentialsService>(),
+        aiSettingsService: locator.get<AiSettingsService>(),
+        backupService: locator.get<BackupService>(),
+        githubStorage: locator.get<GitHubCredentialsStorage>(),
+        githubAuthService: locator.get<GitHubAuthService>(),
+      ),
     )
     // Notes services
     ..registerLazySingleton<NotesDatabase>(() => NotesDatabase())

--- a/lib/src/service_locator.dart
+++ b/lib/src/service_locator.dart
@@ -45,7 +45,9 @@ Future<void> setup() async {
         storage: locator.get<AppSecureStorage>(),
       ),
     )
-    ..registerLazySingleton<AiSettingsService>(() => AiSettingsService())
+    ..registerLazySingleton<AiSettingsService>(
+      () => AiSettingsService(storage: locator.get<AppSecureStorage>()),
+    )
     ..registerLazySingleton<OpenAiService>(() => OpenAiService())
     ..registerLazySingleton<JinaService>(() => JinaService())
     ..registerLazySingleton<AiBookmarkService>(() => AiBookmarkService())

--- a/lib/src/service_locator.dart
+++ b/lib/src/service_locator.dart
@@ -55,7 +55,7 @@ Future<void> setup() async {
       () => BackupService(storage: locator.get<AppSecureStorage>()),
     )
     ..registerLazySingleton<GitHubCredentialsStorage>(
-      () => GitHubCredentialsStorage(),
+      () => GitHubCredentialsStorage(storage: locator.get<AppSecureStorage>()),
     )
     ..registerLazySingleton<GitHubAuthService>(
       () => GitHubAuthService(storage: locator.get<GitHubCredentialsStorage>()),

--- a/lib/src/service_locator.dart
+++ b/lib/src/service_locator.dart
@@ -5,6 +5,7 @@ import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
 import 'package:pinboard_wizard/src/ai/openai/openai_service.dart';
 import 'package:pinboard_wizard/src/ai/web_scraping/jina_service.dart';
 import 'package:pinboard_wizard/src/backup/backup_service.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
 import 'package:pinboard_wizard/src/database/notes_database.dart';
 import 'package:pinboard_wizard/src/github/github_auth_service.dart';
 import 'package:pinboard_wizard/src/github/github_client.dart';
@@ -26,6 +27,12 @@ Future<void> setup() async {
   final appDocDir = await getApplicationDocumentsDirectory();
   final notesDir = appDocDir;
 
+  // Central keychain access — must be initialized before any service reads
+  // credentials, because the sync flag decides which keychain set is active.
+  final appSecureStorage = AppSecureStorage();
+  await appSecureStorage.init();
+  locator.registerSingleton<AppSecureStorage>(appSecureStorage);
+
   locator
     ..registerLazySingleton<PinboardService>(
       () => PinboardService(secretStorage: locator.get<SecretStorage>()),
@@ -33,7 +40,11 @@ Future<void> setup() async {
     ..registerLazySingleton<CredentialsService>(
       () => CredentialsService(storage: locator.get<SecretStorage>()),
     )
-    ..registerLazySingleton<SecretStorage>(() => FlutterSecureSecretsStorage())
+    ..registerLazySingleton<SecretStorage>(
+      () => FlutterSecureSecretsStorage(
+        storage: locator.get<AppSecureStorage>(),
+      ),
+    )
     ..registerLazySingleton<AiSettingsService>(() => AiSettingsService())
     ..registerLazySingleton<OpenAiService>(() => OpenAiService())
     ..registerLazySingleton<JinaService>(() => JinaService())

--- a/lib/src/service_locator.dart
+++ b/lib/src/service_locator.dart
@@ -51,7 +51,9 @@ Future<void> setup() async {
     ..registerLazySingleton<OpenAiService>(() => OpenAiService())
     ..registerLazySingleton<JinaService>(() => JinaService())
     ..registerLazySingleton<AiBookmarkService>(() => AiBookmarkService())
-    ..registerLazySingleton<BackupService>(() => BackupService())
+    ..registerLazySingleton<BackupService>(
+      () => BackupService(storage: locator.get<AppSecureStorage>()),
+    )
     ..registerLazySingleton<GitHubCredentialsStorage>(
       () => GitHubCredentialsStorage(),
     )

--- a/lib/src/ui/controls/app_progress.dart
+++ b/lib/src/ui/controls/app_progress.dart
@@ -15,7 +15,8 @@ class AppProgress extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final resolved = color ??
+    final resolved =
+        color ??
         DefaultTextStyle.of(context).style.color ??
         AppColors.label.resolveFrom(context);
     return GlassProgressIndicator.circular(

--- a/lib/src/ui/controls/app_tabs.dart
+++ b/lib/src/ui/controls/app_tabs.dart
@@ -5,7 +5,7 @@ import '../tokens/app_colors.dart';
 /// Tab controller. Replaces macos_ui `MacosTabController`.
 class AppTabController extends ChangeNotifier {
   AppTabController({required this.length, int initialIndex = 0})
-      : _index = initialIndex;
+    : _index = initialIndex;
   final int length;
   int _index;
   int get index => _index;
@@ -57,7 +57,9 @@ class AppTabView extends StatelessWidget {
                       onTap: () => controller.index = i,
                       child: Container(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 14, vertical: 6),
+                          horizontal: 14,
+                          vertical: 6,
+                        ),
                         margin: const EdgeInsets.symmetric(horizontal: 2),
                         decoration: BoxDecoration(
                           color: controller.index == i
@@ -69,9 +71,7 @@ class AppTabView extends StatelessWidget {
                           tabs[i].label,
                           style: TextStyle(
                             fontSize: 13,
-                            color: controller.index == i
-                                ? Colors.white
-                                : label,
+                            color: controller.index == i ? Colors.white : label,
                           ),
                         ),
                       ),

--- a/lib/src/ui/layout/glass_sidebar.dart
+++ b/lib/src/ui/layout/glass_sidebar.dart
@@ -37,7 +37,9 @@ class GlassSidebar extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            const SizedBox(height: 28), // clear transparent titlebar/traffic lights
+            const SizedBox(
+              height: 28,
+            ), // clear transparent titlebar/traffic lights
             Expanded(
               child: ListView.builder(
                 itemCount: items.length,

--- a/lib/src/ui/overlays/app_dialog.dart
+++ b/lib/src/ui/overlays/app_dialog.dart
@@ -37,8 +37,10 @@ class AppAlertDialog extends StatelessWidget {
                 if (appIcon != null) ...[appIcon!, const SizedBox(height: 12)],
                 DefaultTextStyle.merge(
                   textAlign: TextAlign.center,
-                  style:
-                      const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                  ),
                   child: title,
                 ),
                 if (message != null) ...[
@@ -55,10 +57,7 @@ class AppAlertDialog extends StatelessWidget {
                   const SizedBox(height: 8),
                   secondaryButton!,
                 ],
-                if (suppress != null) ...[
-                  const SizedBox(height: 8),
-                  suppress!,
-                ],
+                if (suppress != null) ...[const SizedBox(height: 8), suppress!],
               ],
             ),
           ),

--- a/lib/src/ui/tokens/app_theme.dart
+++ b/lib/src/ui/tokens/app_theme.dart
@@ -3,22 +3,22 @@ import 'package:liquid_glass_widgets/liquid_glass_widgets.dart';
 import 'app_colors.dart';
 
 ThemeData appLightTheme() => ThemeData(
-      brightness: Brightness.light,
-      useMaterial3: true,
-      colorSchemeSeed: AppColors.accent.color,
-      scaffoldBackgroundColor: Colors.transparent,
-    );
+  brightness: Brightness.light,
+  useMaterial3: true,
+  colorSchemeSeed: AppColors.accent.color,
+  scaffoldBackgroundColor: Colors.transparent,
+);
 
 ThemeData appDarkTheme() => ThemeData(
-      brightness: Brightness.dark,
-      useMaterial3: true,
-      colorSchemeSeed: AppColors.accent.color,
-      scaffoldBackgroundColor: Colors.transparent,
-    );
+  brightness: Brightness.dark,
+  useMaterial3: true,
+  colorSchemeSeed: AppColors.accent.color,
+  scaffoldBackgroundColor: Colors.transparent,
+);
 
 /// App-wide glass defaults passed to `LiquidGlassWidgets.wrap(theme:)`.
 GlassThemeData appGlassTheme() => GlassThemeData.simple(
-      blur: 8,
-      thickness: 24,
-      quality: GlassQuality.standard,
-    );
+  blur: 8,
+  thickness: 24,
+  quality: GlassQuality.standard,
+);

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import file_selector_macos
 import flutter_secure_storage_darwin
 import macos_window_utils
 import package_info_plus
@@ -12,6 +13,7 @@ import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   MacOSWindowUtilsPlugin.register(with: registry.registrar(forPlugin: "MacOSWindowUtilsPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,6 +10,8 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 	<key>keychain-access-groups</key>
   <array>
 		<string>$(AppIdentifierPrefix)dev.richardvancamp.pinboardWizard</string>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
   <key>com.apple.security.application-groups</key>
   <array>
     <string>Y4BC88SNUY.dev.richardvancamp.pinboardWizard</string>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -297,6 +305,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector:
+    dependency: "direct main"
+    description:
+      name: file_selector
+      sha256: bd15e43e9268db636b53eeaca9f56324d1622af30e5c34d6e267649758c84d9a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  file_selector_android:
+    dependency: transitive
+    description:
+      name: file_selector_android
+      sha256: "6a26687fa65cbc28a5345c7ae6f227e89f0b47740978a4c475b1a625da7a331b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2+8"
+  file_selector_ios:
+    dependency: transitive
+    description:
+      name: file_selector_ios
+      sha256: e2ecf2885c121691ce13b60db3508f53c01f869fb6e8dc5c1cfa771e4c46aeca
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.3+5"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_web:
+    dependency: transitive
+    description:
+      name: file_selector_web
+      sha256: "73181fbc5257776d8ecaa6a94ab3c8e920ad143b9132a6d984a9271dfc6928d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_secure_storage: ^10.0.0
   http: ^1.1.0
   url_launcher: ^6.2.5
+  file_selector: ^1.0.3
   get_it: ^9.2.0
   flutter_html: ^3.0.0-beta.2
   bloc: ^9.2.0

--- a/test/ai/ai_settings_service_test.dart
+++ b/test/ai/ai_settings_service_test.dart
@@ -20,7 +20,8 @@ void main() {
     final service = AiSettingsService(storage: appStorage);
     await service.setOpenAiApiKey('sk-test-key');
 
-    final stored = json.decode(fake.local['ai_settings']!) as Map<String, dynamic>;
+    final stored =
+        json.decode(fake.local['ai_settings']!) as Map<String, dynamic>;
     expect((stored['openai'] as Map<String, dynamic>)['apiKey'], 'sk-test-key');
     expect(service.openaiSettings.apiKey, 'sk-test-key');
   });
@@ -29,7 +30,8 @@ void main() {
     final service = AiSettingsService(storage: appStorage);
     await service.setJinaApiKey('jina-test-key-123');
 
-    final stored = json.decode(fake.local['ai_settings']!) as Map<String, dynamic>;
+    final stored =
+        json.decode(fake.local['ai_settings']!) as Map<String, dynamic>;
     expect(
       (stored['webScraping'] as Map<String, dynamic>)['jinaApiKey'],
       'jina-test-key-123',
@@ -39,7 +41,11 @@ void main() {
   test('loads previously stored settings on construction', () async {
     fake.local['ai_settings'] = json.encode({
       'isEnabled': true,
-      'openai': {'apiKey': 'sk-existing', 'descriptionMaxLength': 80, 'maxTags': 3},
+      'openai': {
+        'apiKey': 'sk-existing',
+        'descriptionMaxLength': 80,
+        'maxTags': 3,
+      },
       'webScraping': {'jinaApiKey': null},
     });
 

--- a/test/ai/ai_settings_service_test.dart
+++ b/test/ai/ai_settings_service_test.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+
+import '../common/storage/fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage appStorage;
+
+  setUp(() async {
+    fake = FakeFlutterSecureStorage();
+    appStorage = AppSecureStorage(storage: fake);
+    await appStorage.init();
+  });
+
+  test('persists OpenAI key under ai_settings via AppSecureStorage', () async {
+    final service = AiSettingsService(storage: appStorage);
+    await service.setOpenAiApiKey('sk-test-key');
+
+    final stored = json.decode(fake.local['ai_settings']!) as Map<String, dynamic>;
+    expect((stored['openai'] as Map<String, dynamic>)['apiKey'], 'sk-test-key');
+    expect(service.openaiSettings.apiKey, 'sk-test-key');
+  });
+
+  test('persists Jina key via AppSecureStorage', () async {
+    final service = AiSettingsService(storage: appStorage);
+    await service.setJinaApiKey('jina-test-key-123');
+
+    final stored = json.decode(fake.local['ai_settings']!) as Map<String, dynamic>;
+    expect(
+      (stored['webScraping'] as Map<String, dynamic>)['jinaApiKey'],
+      'jina-test-key-123',
+    );
+  });
+
+  test('loads previously stored settings on construction', () async {
+    fake.local['ai_settings'] = json.encode({
+      'isEnabled': true,
+      'openai': {'apiKey': 'sk-existing', 'descriptionMaxLength': 80, 'maxTags': 3},
+      'webScraping': {'jinaApiKey': null},
+    });
+
+    final service = AiSettingsService(storage: appStorage);
+    // _loadSettings is fire-and-forget in the constructor; let it complete.
+    await Future<void>.delayed(Duration.zero);
+
+    expect(service.settings.isEnabled, isTrue);
+    expect(service.openaiSettings.apiKey, 'sk-existing');
+  });
+}

--- a/test/backup/backup_service_storage_test.dart
+++ b/test/backup/backup_service_storage_test.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/backup/backup_service.dart';
+import 'package:pinboard_wizard/src/backup/models/s3_config.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+
+import '../common/storage/fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage appStorage;
+  late BackupService service;
+
+  setUp(() async {
+    fake = FakeFlutterSecureStorage();
+    appStorage = AppSecureStorage(storage: fake);
+    await appStorage.init();
+    service = BackupService(storage: appStorage);
+  });
+
+  test('saveConfiguration persists under backup_s3_config', () async {
+    const config = S3Config(
+      accessKey: 'AKIA123',
+      secretKey: 'shhh',
+      region: 'eu-west-1',
+      bucketName: 'my-bucket',
+      filePath: 'backups/',
+    );
+
+    await service.saveConfiguration(config);
+
+    final stored =
+        json.decode(fake.local['backup_s3_config']!) as Map<String, dynamic>;
+    expect(stored['accessKey'], 'AKIA123');
+    expect(stored['secretKey'], 'shhh');
+    expect(service.s3Config, config);
+  });
+
+  test('loadConfiguration restores a stored config', () async {
+    fake.local['backup_s3_config'] = json.encode(const S3Config(
+      accessKey: 'AKIA123',
+      secretKey: 'shhh',
+      region: 'eu-west-1',
+      bucketName: 'my-bucket',
+    ).toJson());
+
+    await service.loadConfiguration();
+    expect(service.s3Config.accessKey, 'AKIA123');
+    expect(service.s3Config.bucketName, 'my-bucket');
+  });
+
+  test('clearConfiguration deletes the stored entry', () async {
+    fake.local['backup_s3_config'] = json.encode(const S3Config(
+      accessKey: 'AKIA123',
+      secretKey: 'shhh',
+      region: 'eu-west-1',
+      bucketName: 'my-bucket',
+    ).toJson());
+
+    await service.clearConfiguration();
+    expect(fake.local.containsKey('backup_s3_config'), isFalse);
+    expect(service.s3Config.isEmpty, isTrue);
+  });
+}

--- a/test/backup/backup_service_storage_test.dart
+++ b/test/backup/backup_service_storage_test.dart
@@ -38,12 +38,14 @@ void main() {
   });
 
   test('loadConfiguration restores a stored config', () async {
-    fake.local['backup_s3_config'] = json.encode(const S3Config(
-      accessKey: 'AKIA123',
-      secretKey: 'shhh',
-      region: 'eu-west-1',
-      bucketName: 'my-bucket',
-    ).toJson());
+    fake.local['backup_s3_config'] = json.encode(
+      const S3Config(
+        accessKey: 'AKIA123',
+        secretKey: 'shhh',
+        region: 'eu-west-1',
+        bucketName: 'my-bucket',
+      ).toJson(),
+    );
 
     await service.loadConfiguration();
     expect(service.s3Config.accessKey, 'AKIA123');
@@ -51,12 +53,14 @@ void main() {
   });
 
   test('clearConfiguration deletes the stored entry', () async {
-    fake.local['backup_s3_config'] = json.encode(const S3Config(
-      accessKey: 'AKIA123',
-      secretKey: 'shhh',
-      region: 'eu-west-1',
-      bucketName: 'my-bucket',
-    ).toJson());
+    fake.local['backup_s3_config'] = json.encode(
+      const S3Config(
+        accessKey: 'AKIA123',
+        secretKey: 'shhh',
+        region: 'eu-west-1',
+        bucketName: 'my-bucket',
+      ).toJson(),
+    );
 
     await service.clearConfiguration();
     expect(fake.local.containsKey('backup_s3_config'), isFalse);

--- a/test/common/storage/app_secure_storage_test.dart
+++ b/test/common/storage/app_secure_storage_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+
+import 'fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage storage;
+
+  setUp(() {
+    fake = FakeFlutterSecureStorage();
+    storage = AppSecureStorage(storage: fake);
+  });
+
+  group('init', () {
+    test('defaults to sync disabled when no flag stored', () async {
+      await storage.init();
+      expect(storage.syncEnabled, isFalse);
+    });
+
+    test('loads persisted sync flag from local-only entry', () async {
+      fake.local['secrets_sync_enabled'] = 'true';
+      await storage.init();
+      expect(storage.syncEnabled, isTrue);
+    });
+  });
+
+  group('read/write/delete with sync disabled', () {
+    setUp(() async => storage.init());
+
+    test('writes land in the local bucket only', () async {
+      await storage.write('pinboard_credentials', 'secret');
+      expect(fake.local['pinboard_credentials'], 'secret');
+      expect(fake.synced.containsKey('pinboard_credentials'), isFalse);
+    });
+
+    test('reads ignore dormant synced items', () async {
+      fake.synced['pinboard_credentials'] = 'from-other-mac';
+      expect(await storage.read('pinboard_credentials'), isNull);
+    });
+
+    test('delete removes only the local item', () async {
+      fake.local['ai_settings'] = 'a';
+      fake.synced['ai_settings'] = 'b';
+      await storage.delete('ai_settings');
+      expect(fake.local.containsKey('ai_settings'), isFalse);
+      expect(fake.synced['ai_settings'], 'b');
+    });
+
+    test('containsKey checks the active bucket', () async {
+      fake.local['ai_settings'] = 'a';
+      expect(await storage.containsKey('ai_settings'), isTrue);
+      expect(await storage.containsKey('pinboard_credentials'), isFalse);
+    });
+  });
+
+  group('enabling sync', () {
+    setUp(() async => storage.init());
+
+    test('pushes local-only values into the synced set', () async {
+      fake.local['pinboard_credentials'] = 'mine';
+      await storage.setSyncEnabled(true);
+      expect(fake.synced['pinboard_credentials'], 'mine');
+      expect(fake.local.containsKey('pinboard_credentials'), isFalse);
+    });
+
+    test('synced value wins when both exist', () async {
+      fake.local['pinboard_credentials'] = 'mine';
+      fake.synced['pinboard_credentials'] = 'from-other-mac';
+      await storage.setSyncEnabled(true);
+      expect(fake.synced['pinboard_credentials'], 'from-other-mac');
+      expect(fake.local.containsKey('pinboard_credentials'), isFalse);
+      expect(await storage.read('pinboard_credentials'), 'from-other-mac');
+    });
+
+    test('persists the flag local-only and flips reads to synced set', () async {
+      await storage.setSyncEnabled(true);
+      expect(storage.syncEnabled, isTrue);
+      expect(fake.local['secrets_sync_enabled'], 'true');
+      expect(fake.synced.containsKey('secrets_sync_enabled'), isFalse);
+      await storage.write('ai_settings', 'x');
+      expect(fake.synced['ai_settings'], 'x');
+    });
+
+    test('migrates every known key', () async {
+      for (final key in AppSecureStorage.syncedKeys) {
+        fake.local[key] = 'value-$key';
+      }
+      await storage.setSyncEnabled(true);
+      for (final key in AppSecureStorage.syncedKeys) {
+        expect(fake.synced[key], 'value-$key');
+        expect(fake.local.containsKey(key), isFalse);
+      }
+    });
+  });
+
+  group('disabling sync', () {
+    setUp(() async {
+      await storage.init();
+      await storage.setSyncEnabled(true);
+    });
+
+    test('snapshots synced values to local WITHOUT deleting synced items', () async {
+      fake.synced['pinboard_credentials'] = 'shared';
+      await storage.setSyncEnabled(false);
+      expect(storage.syncEnabled, isFalse);
+      expect(fake.local['pinboard_credentials'], 'shared');
+      // CRITICAL: synced item must survive — deletion would propagate to
+      // every other Mac via iCloud.
+      expect(fake.synced['pinboard_credentials'], 'shared');
+    });
+
+    test('subsequent writes stay local and do not touch the synced set', () async {
+      fake.synced['pinboard_credentials'] = 'shared';
+      await storage.setSyncEnabled(false);
+      await storage.write('pinboard_credentials', 'local-edit');
+      expect(fake.local['pinboard_credentials'], 'local-edit');
+      expect(fake.synced['pinboard_credentials'], 'shared');
+    });
+  });
+
+  test('setSyncEnabled is a no-op when state already matches', () async {
+    await storage.init();
+    fake.local['pinboard_credentials'] = 'mine';
+    await storage.setSyncEnabled(false);
+    expect(fake.local['pinboard_credentials'], 'mine');
+    expect(fake.synced, isEmpty);
+  });
+}

--- a/test/common/storage/app_secure_storage_test.dart
+++ b/test/common/storage/app_secure_storage_test.dart
@@ -131,6 +131,63 @@ void main() {
         expect(throwing.local.containsKey('ai_settings'), isFalse);
       },
     );
+
+    test(
+      'a failed flag write throws and leaves every local copy intact',
+      () async {
+        final throwing = _ThrowingSecureStorage(
+          throwOnWriteOf: AppSecureStorage.syncFlagKey,
+        );
+        final failingStorage = AppSecureStorage(storage: throwing);
+        await failingStorage.init();
+        throwing.local['pinboard_credentials'] = 'creds';
+        throwing.local['ai_settings'] = 'ai';
+
+        await expectLater(
+          failingStorage.setSyncEnabled(true),
+          throwsA(isA<AppSecureStorageException>()),
+        );
+
+        // The flag write is the commit point: nothing may flip and no local
+        // copy may be deleted when it fails — that is the safe retry state.
+        expect(failingStorage.syncEnabled, isFalse);
+        expect(throwing.local.containsKey('secrets_sync_enabled'), isFalse);
+        expect(throwing.local['pinboard_credentials'], 'creds');
+        expect(throwing.local['ai_settings'], 'ai');
+
+        // Retry once the keychain cooperates completes the migration.
+        throwing.throwOnWriteOf = null;
+        await failingStorage.setSyncEnabled(true);
+        expect(failingStorage.syncEnabled, isTrue);
+        expect(throwing.synced['pinboard_credentials'], 'creds');
+        expect(throwing.synced['ai_settings'], 'ai');
+      },
+    );
+
+    test(
+      'a failed local delete does not fail the enable (best-effort cleanup)',
+      () async {
+        final throwing = _ThrowingSecureStorage(
+          throwOnDeleteOf: 'pinboard_credentials',
+        );
+        final failingStorage = AppSecureStorage(storage: throwing);
+        await failingStorage.init();
+        throwing.local['pinboard_credentials'] = 'creds';
+        throwing.local['ai_settings'] = 'ai';
+
+        // Must NOT throw: flag and synced set are already consistent.
+        await failingStorage.setSyncEnabled(true);
+
+        expect(failingStorage.syncEnabled, isTrue);
+        expect(throwing.local['secrets_sync_enabled'], 'true');
+        expect(throwing.synced['pinboard_credentials'], 'creds');
+        expect(throwing.synced['ai_settings'], 'ai');
+        // The leftover local copy is tolerated — it is dormant because all
+        // reads and writes now target the synced set.
+        expect(throwing.local['pinboard_credentials'], 'creds');
+        expect(await failingStorage.read('pinboard_credentials'), 'creds');
+      },
+    );
   });
 
   group('disabling sync', () {
@@ -173,11 +230,13 @@ void main() {
   });
 }
 
-/// Throws on writes of one configurable key; everything else behaves normally.
+/// Throws on writes and/or deletes of one configurable key; everything else
+/// behaves normally.
 class _ThrowingSecureStorage extends FakeFlutterSecureStorage {
-  _ThrowingSecureStorage({required this.throwOnWriteOf});
+  _ThrowingSecureStorage({this.throwOnWriteOf, this.throwOnDeleteOf});
 
   String? throwOnWriteOf;
+  String? throwOnDeleteOf;
 
   @override
   Future<void> write({
@@ -196,6 +255,30 @@ class _ThrowingSecureStorage extends FakeFlutterSecureStorage {
     return super.write(
       key: key,
       value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (key == throwOnDeleteOf) {
+      throw Exception('keychain delete denied');
+    }
+    return super.delete(
+      key: key,
       iOptions: iOptions,
       aOptions: aOptions,
       lOptions: lOptions,

--- a/test/common/storage/app_secure_storage_test.dart
+++ b/test/common/storage/app_secure_storage_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
 
@@ -95,6 +96,41 @@ void main() {
         expect(fake.local.containsKey(key), isFalse);
       }
     });
+
+    test(
+      'a failed write leaves every local copy intact (two-phase migration)',
+      () async {
+        // 'ai_settings' migrates after 'pinboard_credentials' in
+        // AppSecureStorage.syncedKeys, so the failure hits the SECOND write.
+        final throwing = _ThrowingSecureStorage(throwOnWriteOf: 'ai_settings');
+        final failingStorage = AppSecureStorage(storage: throwing);
+        await failingStorage.init();
+        throwing.local['pinboard_credentials'] = 'creds';
+        throwing.local['ai_settings'] = 'ai';
+
+        await expectLater(
+          failingStorage.setSyncEnabled(true),
+          throwsA(isA<AppSecureStorageException>()),
+        );
+
+        expect(failingStorage.syncEnabled, isFalse);
+        // No local copy may be deleted before every write succeeded —
+        // otherwise a partial failure leaves a credential invisible in
+        // both sets.
+        expect(throwing.local['pinboard_credentials'], 'creds');
+        expect(throwing.local['ai_settings'], 'ai');
+
+        // The migration is idempotent: a retry once the keychain cooperates
+        // completes the migration.
+        throwing.throwOnWriteOf = null;
+        await failingStorage.setSyncEnabled(true);
+        expect(failingStorage.syncEnabled, isTrue);
+        expect(throwing.synced['pinboard_credentials'], 'creds');
+        expect(throwing.synced['ai_settings'], 'ai');
+        expect(throwing.local.containsKey('pinboard_credentials'), isFalse);
+        expect(throwing.local.containsKey('ai_settings'), isFalse);
+      },
+    );
   });
 
   group('disabling sync', () {
@@ -135,4 +171,37 @@ void main() {
     expect(fake.local['pinboard_credentials'], 'mine');
     expect(fake.synced, isEmpty);
   });
+}
+
+/// Throws on writes of one configurable key; everything else behaves normally.
+class _ThrowingSecureStorage extends FakeFlutterSecureStorage {
+  _ThrowingSecureStorage({required this.throwOnWriteOf});
+
+  String? throwOnWriteOf;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (key == throwOnWriteOf) {
+      throw Exception('keychain write denied');
+    }
+    return super.write(
+      key: key,
+      value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
 }

--- a/test/common/storage/app_secure_storage_test.dart
+++ b/test/common/storage/app_secure_storage_test.dart
@@ -73,14 +73,17 @@ void main() {
       expect(await storage.read('pinboard_credentials'), 'from-other-mac');
     });
 
-    test('persists the flag local-only and flips reads to synced set', () async {
-      await storage.setSyncEnabled(true);
-      expect(storage.syncEnabled, isTrue);
-      expect(fake.local['secrets_sync_enabled'], 'true');
-      expect(fake.synced.containsKey('secrets_sync_enabled'), isFalse);
-      await storage.write('ai_settings', 'x');
-      expect(fake.synced['ai_settings'], 'x');
-    });
+    test(
+      'persists the flag local-only and flips reads to synced set',
+      () async {
+        await storage.setSyncEnabled(true);
+        expect(storage.syncEnabled, isTrue);
+        expect(fake.local['secrets_sync_enabled'], 'true');
+        expect(fake.synced.containsKey('secrets_sync_enabled'), isFalse);
+        await storage.write('ai_settings', 'x');
+        expect(fake.synced['ai_settings'], 'x');
+      },
+    );
 
     test('migrates every known key', () async {
       for (final key in AppSecureStorage.syncedKeys) {
@@ -100,23 +103,29 @@ void main() {
       await storage.setSyncEnabled(true);
     });
 
-    test('snapshots synced values to local WITHOUT deleting synced items', () async {
-      fake.synced['pinboard_credentials'] = 'shared';
-      await storage.setSyncEnabled(false);
-      expect(storage.syncEnabled, isFalse);
-      expect(fake.local['pinboard_credentials'], 'shared');
-      // CRITICAL: synced item must survive — deletion would propagate to
-      // every other Mac via iCloud.
-      expect(fake.synced['pinboard_credentials'], 'shared');
-    });
+    test(
+      'snapshots synced values to local WITHOUT deleting synced items',
+      () async {
+        fake.synced['pinboard_credentials'] = 'shared';
+        await storage.setSyncEnabled(false);
+        expect(storage.syncEnabled, isFalse);
+        expect(fake.local['pinboard_credentials'], 'shared');
+        // CRITICAL: synced item must survive — deletion would propagate to
+        // every other Mac via iCloud.
+        expect(fake.synced['pinboard_credentials'], 'shared');
+      },
+    );
 
-    test('subsequent writes stay local and do not touch the synced set', () async {
-      fake.synced['pinboard_credentials'] = 'shared';
-      await storage.setSyncEnabled(false);
-      await storage.write('pinboard_credentials', 'local-edit');
-      expect(fake.local['pinboard_credentials'], 'local-edit');
-      expect(fake.synced['pinboard_credentials'], 'shared');
-    });
+    test(
+      'subsequent writes stay local and do not touch the synced set',
+      () async {
+        fake.synced['pinboard_credentials'] = 'shared';
+        await storage.setSyncEnabled(false);
+        await storage.write('pinboard_credentials', 'local-edit');
+        expect(fake.local['pinboard_credentials'], 'local-edit');
+        expect(fake.synced['pinboard_credentials'], 'shared');
+      },
+    );
   });
 
   test('setSyncEnabled is a no-op when state already matches', () async {

--- a/test/common/storage/fake_flutter_secure_storage.dart
+++ b/test/common/storage/fake_flutter_secure_storage.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// In-memory fake keyed by (key, synchronizable) — mirrors how the macOS
+/// keychain treats local-only and synchronizable items as distinct.
+class FakeFlutterSecureStorage extends Fake implements FlutterSecureStorage {
+  final Map<String, String> local = {};
+  final Map<String, String> synced = {};
+
+  Map<String, String> _bucket(AppleOptions? mOptions) {
+    final isSynced = mOptions != null && mOptions.synchronizable;
+    return isSynced ? synced : local;
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => _bucket(mOptions)[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      _bucket(mOptions).remove(key);
+    } else {
+      _bucket(mOptions)[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    _bucket(mOptions).remove(key);
+  }
+
+  @override
+  Future<bool> containsKey({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async => _bucket(mOptions).containsKey(key);
+}

--- a/test/env_import/env_file_parser_test.dart
+++ b/test/env_import/env_file_parser_test.dart
@@ -51,6 +51,21 @@ void main() {
     expect(result.variables['TOKEN'], 'abc=def==');
   });
 
+  test('strips unquoted inline comments preceded by whitespace', () {
+    final result = parser.parse('KEY=sk-abc123 # my key');
+    expect(result.variables['KEY'], 'sk-abc123');
+  });
+
+  test('keeps # inside quoted values', () {
+    final result = parser.parse('KEY="value # keep"');
+    expect(result.variables['KEY'], 'value # keep');
+  });
+
+  test('keeps # not preceded by whitespace in unquoted values', () {
+    final result = parser.parse('KEY=abc#def');
+    expect(result.variables['KEY'], 'abc#def');
+  });
+
   test('trims whitespace around key and value', () {
     final result = parser.parse('  KEY  =  value  ');
     expect(result.variables, {'KEY': 'value'});

--- a/test/env_import/env_file_parser_test.dart
+++ b/test/env_import/env_file_parser_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/env_import/env_file_parser.dart';
+
+void main() {
+  final parser = EnvFileParser();
+
+  test('parses simple KEY=VALUE lines', () {
+    final result = parser.parse('PINBOARD_API_TOKEN=user:abc123\n');
+    expect(result.variables, {'PINBOARD_API_TOKEN': 'user:abc123'});
+    expect(result.ignoredLines, 0);
+  });
+
+  test('strips export prefix', () {
+    final result = parser.parse('export OPENAI_API_KEY=sk-123');
+    expect(result.variables, {'OPENAI_API_KEY': 'sk-123'});
+  });
+
+  test('strips matching single and double quotes', () {
+    final result = parser.parse(
+      'A="double quoted"\nB=\'single quoted\'\nC="unbalanced\'',
+    );
+    expect(result.variables['A'], 'double quoted');
+    expect(result.variables['B'], 'single quoted');
+    expect(result.variables['C'], '"unbalanced\''); // mismatched quotes kept
+  });
+
+  test('skips blank lines and comments without counting them as ignored', () {
+    final result = parser.parse('\n# a comment\n\nKEY=value\n');
+    expect(result.variables, {'KEY': 'value'});
+    expect(result.ignoredLines, 0);
+  });
+
+  test('counts unparseable lines as ignored', () {
+    final result = parser.parse('not a var line\nKEY=value\n:::\n');
+    expect(result.variables, {'KEY': 'value'});
+    expect(result.ignoredLines, 2);
+  });
+
+  test('tolerates CRLF line endings', () {
+    final result = parser.parse('A=1\r\nB=2\r\n');
+    expect(result.variables, {'A': '1', 'B': '2'});
+  });
+
+  test('later duplicate keys win', () {
+    final result = parser.parse('A=first\nA=second\n');
+    expect(result.variables['A'], 'second');
+  });
+
+  test('keeps = signs inside values', () {
+    final result = parser.parse('TOKEN=abc=def==');
+    expect(result.variables['TOKEN'], 'abc=def==');
+  });
+
+  test('trims whitespace around key and value', () {
+    final result = parser.parse('  KEY  =  value  ');
+    expect(result.variables, {'KEY': 'value'});
+  });
+}

--- a/test/env_import/env_file_parser_test.dart
+++ b/test/env_import/env_file_parser_test.dart
@@ -66,6 +66,11 @@ void main() {
     expect(result.variables['KEY'], 'abc#def');
   });
 
+  test('treats a value that is only a comment as empty', () {
+    final result = parser.parse('KEY= # comment');
+    expect(result.variables['KEY'], '');
+  });
+
   test('trims whitespace around key and value', () {
     final result = parser.parse('  KEY  =  value  ');
     expect(result.variables, {'KEY': 'value'});

--- a/test/env_import/env_import_service_test.dart
+++ b/test/env_import/env_import_service_test.dart
@@ -242,6 +242,33 @@ void main() {
       expect(throwingFake.synced.containsKey('backup_s3_config'), isFalse);
     });
 
+    test('a stale backup error does not fail a later S3 import', () async {
+      final flakyFake = _ThrowingBackupStorage();
+      final flakyAppStorage = AppSecureStorage(storage: flakyFake);
+      await flakyAppStorage.init();
+      final flakyBackupService = BackupService(storage: flakyAppStorage);
+      // Drive the service into an error state with a failed save…
+      await flakyBackupService.saveConfiguration(const S3Config());
+      expect(flakyBackupService.status, BackupStatus.error);
+
+      // …then let the storage work again: apply() must not mistake the
+      // stale error for a load failure.
+      flakyFake.throwing = false;
+      final workingService = EnvImportService(
+        credentialsService: credentialsService,
+        aiSettingsService: aiSettingsService,
+        backupService: flakyBackupService,
+        githubStorage: githubStorage,
+        githubAuthService: githubAuthService,
+      );
+
+      final result = await workingService.apply({'AWS_REGION': 'eu-west-1'});
+
+      expect(result.applied, ['AWS_REGION']);
+      expect(result.failed, isEmpty);
+      expect(flakyBackupService.s3Config.region, 'eu-west-1');
+    });
+
     test(
       'GitHub token save failure fails only GITHUB_PAT; config persists',
       () async {
@@ -276,8 +303,10 @@ void main() {
   });
 }
 
-/// Fails writes of the S3 backup config key; everything else behaves normally.
+/// Fails writes of the S3 backup config key while [throwing] is set;
+/// everything else behaves normally.
 class _ThrowingBackupStorage extends FakeFlutterSecureStorage {
+  bool throwing = true;
   @override
   Future<void> write({
     required String key,
@@ -289,7 +318,7 @@ class _ThrowingBackupStorage extends FakeFlutterSecureStorage {
     AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async {
-    if (key == 'backup_s3_config') {
+    if (throwing && key == 'backup_s3_config') {
       throw Exception('keychain write denied');
     }
     return super.write(

--- a/test/env_import/env_import_service_test.dart
+++ b/test/env_import/env_import_service_test.dart
@@ -84,6 +84,18 @@ void main() {
       expect(creds?.apiKey, 'new:1111111111');
     });
 
+    test('rejects a malformed pinboard token without saving it', () async {
+      final result = await service.apply({'PINBOARD_API_TOKEN': 'not-a-token'});
+
+      expect(
+        result.failed['PINBOARD_API_TOKEN'],
+        'Invalid Pinboard token format (expected username:hexstring)',
+      );
+      expect(result.applied, isNot(contains('PINBOARD_API_TOKEN')));
+      expect(await credentialsService.getCredentials(), isNull);
+      expect(credentialsService.isAuthenticatedNotifier.value, isFalse);
+    });
+
     test('imports AI keys', () async {
       final result = await service.apply({
         'OPENAI_API_KEY': 'sk-abc',

--- a/test/env_import/env_import_service_test.dart
+++ b/test/env_import/env_import_service_test.dart
@@ -309,6 +309,9 @@ void main() {
         final config = await failingGithubStorage.readConfig();
         expect(config?.owner, 'octocat');
         expect(config?.repo, 'notes');
+        // The token never persisted, so the saved config must not claim to
+        // be configured.
+        expect(config?.isConfigured, isFalse);
         expect(await failingGithubStorage.readToken(), isNull);
       },
     );

--- a/test/env_import/env_import_service_test.dart
+++ b/test/env_import/env_import_service_test.dart
@@ -56,7 +56,9 @@ void main() {
 
   group('apply', () {
     test('imports pinboard token and authenticates', () async {
-      final result = await service.apply({'PINBOARD_API_TOKEN': 'user:abc123def'});
+      final result = await service.apply({
+        'PINBOARD_API_TOKEN': 'user:abc123def',
+      });
 
       expect(result.applied, contains('PINBOARD_API_TOKEN'));
       expect(result.failed, isEmpty);
@@ -83,12 +85,14 @@ void main() {
     });
 
     test('partial S3 import merges with the existing config', () async {
-      await backupService.saveConfiguration(const S3Config(
-        accessKey: 'OLD_ACCESS',
-        secretKey: 'OLD_SECRET',
-        region: 'us-east-1',
-        bucketName: 'old-bucket',
-      ));
+      await backupService.saveConfiguration(
+        const S3Config(
+          accessKey: 'OLD_ACCESS',
+          secretKey: 'OLD_SECRET',
+          region: 'us-east-1',
+          bucketName: 'old-bucket',
+        ),
+      );
 
       await service.apply({'AWS_SECRET_ACCESS_KEY': 'NEW_SECRET'});
 
@@ -97,22 +101,25 @@ void main() {
       expect(backupService.s3Config.bucketName, 'old-bucket');
     });
 
-    test('creates a GitHub config with generated deviceId when none exists', () async {
-      final result = await service.apply({
-        'GITHUB_PAT': 'ghp_secret123',
-        'GITHUB_OWNER': 'octocat',
-        'GITHUB_REPO': 'notes',
-      });
+    test(
+      'creates a GitHub config with generated deviceId when none exists',
+      () async {
+        final result = await service.apply({
+          'GITHUB_PAT': 'ghp_secret123',
+          'GITHUB_OWNER': 'octocat',
+          'GITHUB_REPO': 'notes',
+        });
 
-      expect(result.failed, isEmpty);
-      final config = await githubStorage.readConfig();
-      expect(config?.owner, 'octocat');
-      expect(config?.repo, 'notes');
-      expect(config?.branch, 'main');
-      expect(config?.deviceId, isNotEmpty);
-      expect(config?.isConfigured, isTrue);
-      expect(await githubStorage.readToken(), 'ghp_secret123');
-    });
+        expect(result.failed, isEmpty);
+        final config = await githubStorage.readConfig();
+        expect(config?.owner, 'octocat');
+        expect(config?.repo, 'notes');
+        expect(config?.branch, 'main');
+        expect(config?.deviceId, isNotEmpty);
+        expect(config?.isConfigured, isTrue);
+        expect(await githubStorage.readToken(), 'ghp_secret123');
+      },
+    );
 
     test('merges GitHub fields into an existing config', () async {
       await githubStorage.saveAll(
@@ -134,13 +141,19 @@ void main() {
       expect(await githubStorage.readToken(), 'ghp_old');
     });
 
-    test('GitHub config without token is saved but not marked configured', () async {
-      await service.apply({'GITHUB_OWNER': 'octocat', 'GITHUB_REPO': 'notes'});
+    test(
+      'GitHub config without token is saved but not marked configured',
+      () async {
+        await service.apply({
+          'GITHUB_OWNER': 'octocat',
+          'GITHUB_REPO': 'notes',
+        });
 
-      final config = await githubStorage.readConfig();
-      expect(config?.owner, 'octocat');
-      expect(config?.isConfigured, isFalse);
-    });
+        final config = await githubStorage.readConfig();
+        expect(config?.owner, 'octocat');
+        expect(config?.isConfigured, isFalse);
+      },
+    );
 
     test('unknown variables are not applied', () async {
       final result = await service.apply({'TOTALLY_UNKNOWN': 'x'});

--- a/test/env_import/env_import_service_test.dart
+++ b/test/env_import/env_import_service_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
+import 'package:pinboard_wizard/src/backup/backup_service.dart';
+import 'package:pinboard_wizard/src/backup/models/s3_config.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
+import 'package:pinboard_wizard/src/github/github_auth_service.dart';
+import 'package:pinboard_wizard/src/github/github_credentials_storage.dart';
+import 'package:pinboard_wizard/src/github/models/github_notes_config.dart';
+import 'package:pinboard_wizard/src/pinboard/credentials_service.dart';
+import 'package:pinboard_wizard/src/pinboard/flutter_secure_secrets_storage.dart';
+
+import '../common/storage/fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage appStorage;
+  late CredentialsService credentialsService;
+  late AiSettingsService aiSettingsService;
+  late BackupService backupService;
+  late GitHubCredentialsStorage githubStorage;
+  late GitHubAuthService githubAuthService;
+  late EnvImportService service;
+
+  setUp(() async {
+    fake = FakeFlutterSecureStorage();
+    appStorage = AppSecureStorage(storage: fake);
+    await appStorage.init();
+    credentialsService = CredentialsService(
+      storage: FlutterSecureSecretsStorage(storage: appStorage),
+    );
+    aiSettingsService = AiSettingsService(storage: appStorage);
+    backupService = BackupService(storage: appStorage);
+    githubStorage = GitHubCredentialsStorage(storage: appStorage);
+    githubAuthService = GitHubAuthService(storage: githubStorage);
+    service = EnvImportService(
+      credentialsService: credentialsService,
+      aiSettingsService: aiSettingsService,
+      backupService: backupService,
+      githubStorage: githubStorage,
+      githubAuthService: githubAuthService,
+    );
+  });
+
+  group('preview', () {
+    test('splits recognized from unrecognized variables', () {
+      final preview = service.preview(
+        'PINBOARD_API_TOKEN=user:abc\nAPPLE_ID=someone@example.com\njunk line\n',
+      );
+      expect(preview.recognized, {'PINBOARD_API_TOKEN': 'user:abc'});
+      expect(preview.unrecognized, ['APPLE_ID']);
+      expect(preview.ignoredLines, 1);
+    });
+  });
+
+  group('apply', () {
+    test('imports pinboard token and authenticates', () async {
+      final result = await service.apply({'PINBOARD_API_TOKEN': 'user:abc123def'});
+
+      expect(result.applied, contains('PINBOARD_API_TOKEN'));
+      expect(result.failed, isEmpty);
+      final creds = await credentialsService.getCredentials();
+      expect(creds?.apiKey, 'user:abc123def');
+    });
+
+    test('env value wins over an existing stored value', () async {
+      await credentialsService.saveCredentials('old:0000000000');
+      await service.apply({'PINBOARD_API_TOKEN': 'new:1111111111'});
+      final creds = await credentialsService.getCredentials();
+      expect(creds?.apiKey, 'new:1111111111');
+    });
+
+    test('imports AI keys', () async {
+      final result = await service.apply({
+        'OPENAI_API_KEY': 'sk-abc',
+        'JINA_API_KEY': 'jina-abc',
+      });
+
+      expect(result.applied, containsAll(['OPENAI_API_KEY', 'JINA_API_KEY']));
+      expect(aiSettingsService.openaiSettings.apiKey, 'sk-abc');
+      expect(aiSettingsService.settings.webScraping.jinaApiKey, 'jina-abc');
+    });
+
+    test('partial S3 import merges with the existing config', () async {
+      await backupService.saveConfiguration(const S3Config(
+        accessKey: 'OLD_ACCESS',
+        secretKey: 'OLD_SECRET',
+        region: 'us-east-1',
+        bucketName: 'old-bucket',
+      ));
+
+      await service.apply({'AWS_SECRET_ACCESS_KEY': 'NEW_SECRET'});
+
+      expect(backupService.s3Config.secretKey, 'NEW_SECRET');
+      expect(backupService.s3Config.accessKey, 'OLD_ACCESS');
+      expect(backupService.s3Config.bucketName, 'old-bucket');
+    });
+
+    test('creates a GitHub config with generated deviceId when none exists', () async {
+      final result = await service.apply({
+        'GITHUB_PAT': 'ghp_secret123',
+        'GITHUB_OWNER': 'octocat',
+        'GITHUB_REPO': 'notes',
+      });
+
+      expect(result.failed, isEmpty);
+      final config = await githubStorage.readConfig();
+      expect(config?.owner, 'octocat');
+      expect(config?.repo, 'notes');
+      expect(config?.branch, 'main');
+      expect(config?.deviceId, isNotEmpty);
+      expect(config?.isConfigured, isTrue);
+      expect(await githubStorage.readToken(), 'ghp_secret123');
+    });
+
+    test('merges GitHub fields into an existing config', () async {
+      await githubStorage.saveAll(
+        config: const GitHubNotesConfig(
+          owner: 'octocat',
+          repo: 'old-repo',
+          deviceId: 'device-1',
+          isConfigured: true,
+        ),
+        token: 'ghp_old',
+      );
+
+      await service.apply({'GITHUB_REPO': 'new-repo'});
+
+      final config = await githubStorage.readConfig();
+      expect(config?.repo, 'new-repo');
+      expect(config?.owner, 'octocat');
+      expect(config?.deviceId, 'device-1');
+      expect(await githubStorage.readToken(), 'ghp_old');
+    });
+
+    test('GitHub config without token is saved but not marked configured', () async {
+      await service.apply({'GITHUB_OWNER': 'octocat', 'GITHUB_REPO': 'notes'});
+
+      final config = await githubStorage.readConfig();
+      expect(config?.owner, 'octocat');
+      expect(config?.isConfigured, isFalse);
+    });
+
+    test('unknown variables are not applied', () async {
+      final result = await service.apply({'TOTALLY_UNKNOWN': 'x'});
+      expect(result.applied, isEmpty);
+      expect(result.failed, isEmpty);
+    });
+
+    test('a failing group is reported without blocking others', () async {
+      // Empty pinboard token makes CredentialsService.saveCredentials throw.
+      final result = await service.apply({
+        'PINBOARD_API_TOKEN': '   ',
+        'OPENAI_API_KEY': 'sk-abc',
+      });
+
+      expect(result.failed.keys, contains('PINBOARD_API_TOKEN'));
+      expect(result.applied, contains('OPENAI_API_KEY'));
+      expect(aiSettingsService.openaiSettings.apiKey, 'sk-abc');
+    });
+  });
+}

--- a/test/env_import/env_import_service_test.dart
+++ b/test/env_import/env_import_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
 import 'package:pinboard_wizard/src/backup/backup_service.dart';
@@ -158,5 +159,59 @@ void main() {
       expect(result.applied, contains('OPENAI_API_KEY'));
       expect(aiSettingsService.openaiSettings.apiKey, 'sk-abc');
     });
+
+    test('S3 save failure is reported as failed, not applied', () async {
+      // BackupService.saveConfiguration swallows storage errors into
+      // status/lastError instead of throwing; apply() must still report them.
+      final throwingFake = _ThrowingBackupStorage();
+      final throwingAppStorage = AppSecureStorage(storage: throwingFake);
+      await throwingAppStorage.init();
+      final failingBackupService = BackupService(storage: throwingAppStorage);
+      final failingService = EnvImportService(
+        credentialsService: credentialsService,
+        aiSettingsService: aiSettingsService,
+        backupService: failingBackupService,
+        githubStorage: githubStorage,
+        githubAuthService: githubAuthService,
+      );
+
+      final result = await failingService.apply({
+        'AWS_SECRET_ACCESS_KEY': 'X',
+        'OPENAI_API_KEY': 'sk-ok',
+      });
+
+      expect(result.failed.keys, contains('AWS_SECRET_ACCESS_KEY'));
+      expect(result.applied, isNot(contains('AWS_SECRET_ACCESS_KEY')));
+      expect(result.applied, contains('OPENAI_API_KEY'));
+    });
   });
+}
+
+/// Fails writes of the S3 backup config key; everything else behaves normally.
+class _ThrowingBackupStorage extends FakeFlutterSecureStorage {
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (key == 'backup_s3_config') {
+      throw Exception('keychain write denied');
+    }
+    return super.write(
+      key: key,
+      value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
 }

--- a/test/env_import/env_import_service_test.dart
+++ b/test/env_import/env_import_service_test.dart
@@ -52,6 +52,17 @@ void main() {
       expect(preview.unrecognized, ['APPLE_ID']);
       expect(preview.ignoredLines, 1);
     });
+
+    test('skips recognized variables with empty values', () {
+      final preview = service.preview(
+        'OPENAI_API_KEY=\nPINBOARD_API_TOKEN=user:abc\n',
+      );
+      expect(preview.recognized, {'PINBOARD_API_TOKEN': 'user:abc'});
+      expect(preview.unrecognized, isEmpty);
+      // The empty assignment counts as an ignored line — importing it
+      // would clear the stored credential.
+      expect(preview.ignoredLines, 1);
+    });
   });
 
   group('apply', () {
@@ -197,6 +208,71 @@ void main() {
       expect(result.applied, isNot(contains('AWS_SECRET_ACCESS_KEY')));
       expect(result.applied, contains('OPENAI_API_KEY'));
     });
+
+    test('S3 load failure fails the S3 keys and skips the save', () async {
+      // A failed load must not be merged into (and overwrite) whatever the
+      // real stored config is.
+      final throwingFake = _ThrowingReadBackupStorage();
+      final throwingAppStorage = AppSecureStorage(storage: throwingFake);
+      await throwingAppStorage.init();
+      final failingBackupService = BackupService(storage: throwingAppStorage);
+      final failingService = EnvImportService(
+        credentialsService: credentialsService,
+        aiSettingsService: aiSettingsService,
+        backupService: failingBackupService,
+        githubStorage: githubStorage,
+        githubAuthService: githubAuthService,
+      );
+
+      final result = await failingService.apply({
+        'AWS_ACCESS_KEY_ID': 'AKIA123',
+        'AWS_SECRET_ACCESS_KEY': 'X',
+        'OPENAI_API_KEY': 'sk-ok',
+      });
+
+      expect(
+        result.failed.keys,
+        containsAll(['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY']),
+      );
+      expect(result.applied, isNot(contains('AWS_ACCESS_KEY_ID')));
+      expect(result.applied, isNot(contains('AWS_SECRET_ACCESS_KEY')));
+      expect(result.applied, contains('OPENAI_API_KEY'));
+      // Nothing was saved.
+      expect(throwingFake.local.containsKey('backup_s3_config'), isFalse);
+      expect(throwingFake.synced.containsKey('backup_s3_config'), isFalse);
+    });
+
+    test(
+      'GitHub token save failure fails only GITHUB_PAT; config persists',
+      () async {
+        final throwingFake = _ThrowingTokenStorage();
+        final throwingAppStorage = AppSecureStorage(storage: throwingFake);
+        await throwingAppStorage.init();
+        final failingGithubStorage = GitHubCredentialsStorage(
+          storage: throwingAppStorage,
+        );
+        final failingService = EnvImportService(
+          credentialsService: credentialsService,
+          aiSettingsService: aiSettingsService,
+          backupService: backupService,
+          githubStorage: failingGithubStorage,
+          githubAuthService: GitHubAuthService(storage: failingGithubStorage),
+        );
+
+        final result = await failingService.apply({
+          'GITHUB_OWNER': 'octocat',
+          'GITHUB_REPO': 'notes',
+          'GITHUB_PAT': 'ghp_secret123',
+        });
+
+        expect(result.applied, containsAll(['GITHUB_OWNER', 'GITHUB_REPO']));
+        expect(result.failed.keys, ['GITHUB_PAT']);
+        final config = await failingGithubStorage.readConfig();
+        expect(config?.owner, 'octocat');
+        expect(config?.repo, 'notes');
+        expect(await failingGithubStorage.readToken(), isNull);
+      },
+    );
   });
 }
 
@@ -214,6 +290,62 @@ class _ThrowingBackupStorage extends FakeFlutterSecureStorage {
     WindowsOptions? wOptions,
   }) async {
     if (key == 'backup_s3_config') {
+      throw Exception('keychain write denied');
+    }
+    return super.write(
+      key: key,
+      value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
+}
+
+/// Fails reads of the S3 backup config key; everything else behaves normally.
+class _ThrowingReadBackupStorage extends FakeFlutterSecureStorage {
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (key == 'backup_s3_config') {
+      throw Exception('keychain read denied');
+    }
+    return super.read(
+      key: key,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
+}
+
+/// Fails writes of the GitHub PAT key; everything else behaves normally.
+class _ThrowingTokenStorage extends FakeFlutterSecureStorage {
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (key == 'github_pat_token') {
       throw Exception('keychain write denied');
     }
     return super.write(

--- a/test/github/github_credentials_storage_test.dart
+++ b/test/github/github_credentials_storage_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/github/github_credentials_storage.dart';
+import 'package:pinboard_wizard/src/github/models/github_notes_config.dart';
+
+import '../common/storage/fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage appStorage;
+  late GitHubCredentialsStorage storage;
+
+  const config = GitHubNotesConfig(
+    owner: 'octocat',
+    repo: 'notes',
+    deviceId: 'device-1',
+    isConfigured: true,
+  );
+
+  setUp(() async {
+    fake = FakeFlutterSecureStorage();
+    appStorage = AppSecureStorage(storage: fake);
+    await appStorage.init();
+    storage = GitHubCredentialsStorage(storage: appStorage);
+  });
+
+  test('saveAll persists config and token under their keychain keys', () async {
+    await storage.saveAll(config: config, token: 'ghp_token123');
+
+    expect(fake.local['github_notes_config'], contains('octocat'));
+    expect(fake.local['github_pat_token'], 'ghp_token123');
+  });
+
+  test('readConfig and readToken round-trip', () async {
+    await storage.saveAll(config: config, token: 'ghp_token123');
+
+    final readBack = await storage.readConfig();
+    expect(readBack?.owner, 'octocat');
+    expect(readBack?.repo, 'notes');
+    expect(await storage.readToken(), 'ghp_token123');
+    expect(await storage.isConfigured(), isTrue);
+  });
+
+  test('clearAll removes both entries', () async {
+    await storage.saveAll(config: config, token: 'ghp_token123');
+    await storage.clearAll();
+
+    expect(await storage.readConfig(), isNull);
+    expect(await storage.readToken(), isNull);
+    expect(await storage.isConfigured(), isFalse);
+  });
+}

--- a/test/pages/settings/state/settings_cubit_safe_emit_test.dart
+++ b/test/pages/settings/state/settings_cubit_safe_emit_test.dart
@@ -6,11 +6,15 @@ import 'package:pinboard_wizard/src/ai/ai_settings.dart';
 import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
 import 'package:pinboard_wizard/src/backup/backup_service.dart';
 import 'package:pinboard_wizard/src/backup/models/s3_config.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
 import 'package:pinboard_wizard/src/github/github_auth_service.dart';
+import 'package:pinboard_wizard/src/github/github_credentials_storage.dart';
 import 'package:pinboard_wizard/src/pages/settings/state/settings_cubit.dart';
 import 'package:pinboard_wizard/src/pinboard/credentials_service.dart';
 import 'package:pinboard_wizard/src/pinboard/pinboard_service.dart';
 
+import '../../../common/storage/fake_flutter_secure_storage.dart';
 import 'settings_cubit_safe_emit_test.mocks.dart';
 
 @GenerateMocks([
@@ -27,6 +31,8 @@ void main() {
     late MockAiSettingsService mockAiSettingsService;
     late MockBackupService mockBackupService;
     late MockGitHubAuthService mockGitHubAuthService;
+    late AppSecureStorage appSecureStorage;
+    late EnvImportService envImportService;
     late SettingsCubit settingsCubit;
 
     setUp(() {
@@ -35,6 +41,14 @@ void main() {
       mockAiSettingsService = MockAiSettingsService();
       mockBackupService = MockBackupService();
       mockGitHubAuthService = MockGitHubAuthService();
+      appSecureStorage = AppSecureStorage(storage: FakeFlutterSecureStorage());
+      envImportService = EnvImportService(
+        credentialsService: mockCredentialsService,
+        aiSettingsService: mockAiSettingsService,
+        backupService: mockBackupService,
+        githubStorage: GitHubCredentialsStorage(storage: appSecureStorage),
+        githubAuthService: mockGitHubAuthService,
+      );
 
       // Setup default mock behaviors
       when(
@@ -56,6 +70,8 @@ void main() {
         aiSettingsService: mockAiSettingsService,
         backupService: mockBackupService,
         githubAuthService: mockGitHubAuthService,
+        appSecureStorage: appSecureStorage,
+        envImportService: envImportService,
       );
     });
 
@@ -140,6 +156,8 @@ void main() {
           aiSettingsService: mockAiSettingsService,
           backupService: mockBackupService,
           githubAuthService: mockGitHubAuthService,
+          appSecureStorage: appSecureStorage,
+          envImportService: envImportService,
         );
 
         // Close the cubit

--- a/test/pages/settings/state/settings_cubit_sync_test.dart
+++ b/test/pages/settings/state/settings_cubit_sync_test.dart
@@ -111,6 +111,34 @@ void main() {
       expect(aiSettingsService.openaiSettings.apiKey, 'sk-1');
     },
   );
+
+  test(
+    'importEnvVariables clears the stale message before a new import',
+    () async {
+      await cubit.importEnvVariables({'OPENAI_API_KEY': 'sk-1'});
+      expect(cubit.state.envImportMessage, isNotNull);
+
+      final messages = <String?>[];
+      final subscription = cubit.stream.listen(
+        (state) => messages.add(state.envImportMessage),
+      );
+      await cubit.importEnvVariables({'JINA_API_KEY': 'jina-1'});
+      await subscription.cancel();
+
+      // The very first emission of the second import clears the old banner.
+      expect(messages.first, isNull);
+      expect(cubit.state.envImportMessage, contains('1'));
+    },
+  );
+
+  test('clearEnvImportMessage dismisses the banner', () async {
+    await cubit.importEnvVariables({'OPENAI_API_KEY': 'sk-1'});
+    expect(cubit.state.envImportMessage, isNotNull);
+
+    cubit.clearEnvImportMessage();
+
+    expect(cubit.state.envImportMessage, isNull);
+  });
 }
 
 /// Throws on writes of one configurable key; everything else behaves normally.

--- a/test/pages/settings/state/settings_cubit_sync_test.dart
+++ b/test/pages/settings/state/settings_cubit_sync_test.dart
@@ -75,10 +75,13 @@ void main() {
     expect(preview.unrecognized, ['RANDOM']);
   });
 
-  test('importEnvVariables applies values and sets a summary message', () async {
-    await cubit.importEnvVariables({'OPENAI_API_KEY': 'sk-1'});
+  test(
+    'importEnvVariables applies values and sets a summary message',
+    () async {
+      await cubit.importEnvVariables({'OPENAI_API_KEY': 'sk-1'});
 
-    expect(cubit.state.envImportMessage, contains('1'));
-    expect(aiSettingsService.openaiSettings.apiKey, 'sk-1');
-  });
+      expect(cubit.state.envImportMessage, contains('1'));
+      expect(aiSettingsService.openaiSettings.apiKey, 'sk-1');
+    },
+  );
 }

--- a/test/pages/settings/state/settings_cubit_sync_test.dart
+++ b/test/pages/settings/state/settings_cubit_sync_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
+import 'package:pinboard_wizard/src/backup/backup_service.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
+import 'package:pinboard_wizard/src/github/github_auth_service.dart';
+import 'package:pinboard_wizard/src/github/github_credentials_storage.dart';
+import 'package:pinboard_wizard/src/pages/settings/state/settings_cubit.dart';
+import 'package:pinboard_wizard/src/pinboard/credentials_service.dart';
+import 'package:pinboard_wizard/src/pinboard/flutter_secure_secrets_storage.dart';
+import 'package:pinboard_wizard/src/pinboard/pinboard_service.dart';
+import 'package:pinboard_wizard/src/pinboard/secrets_storage.dart';
+
+import '../../../common/storage/fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage appStorage;
+  late SettingsCubit cubit;
+  late SecretStorage secretStorage;
+  late CredentialsService credentialsService;
+  late AiSettingsService aiSettingsService;
+  late BackupService backupService;
+  late GitHubCredentialsStorage githubStorage;
+  late GitHubAuthService githubAuthService;
+
+  setUp(() async {
+    fake = FakeFlutterSecureStorage();
+    appStorage = AppSecureStorage(storage: fake);
+    await appStorage.init();
+    secretStorage = FlutterSecureSecretsStorage(storage: appStorage);
+    credentialsService = CredentialsService(storage: secretStorage);
+    aiSettingsService = AiSettingsService(storage: appStorage);
+    backupService = BackupService(storage: appStorage);
+    githubStorage = GitHubCredentialsStorage(storage: appStorage);
+    githubAuthService = GitHubAuthService(storage: githubStorage);
+    cubit = SettingsCubit(
+      credentialsService: credentialsService,
+      pinboardService: PinboardService(secretStorage: secretStorage),
+      aiSettingsService: aiSettingsService,
+      backupService: backupService,
+      githubAuthService: githubAuthService,
+      appSecureStorage: appStorage,
+      envImportService: EnvImportService(
+        credentialsService: credentialsService,
+        aiSettingsService: aiSettingsService,
+        backupService: backupService,
+        githubStorage: githubStorage,
+        githubAuthService: githubAuthService,
+      ),
+    );
+  });
+
+  tearDown(() => cubit.close());
+
+  test('loadSettings surfaces the persisted sync flag', () async {
+    fake.local['secrets_sync_enabled'] = 'true';
+    await appStorage.init();
+    await cubit.loadSettings();
+    expect(cubit.state.secretsSyncEnabled, isTrue);
+  });
+
+  test('setSecretsSyncEnabled(true) migrates and updates state', () async {
+    fake.local['pinboard_credentials'] = '{"apiKey":"user:abc"}';
+
+    await cubit.setSecretsSyncEnabled(true);
+
+    expect(cubit.state.secretsSyncEnabled, isTrue);
+    expect(fake.synced['pinboard_credentials'], '{"apiKey":"user:abc"}');
+  });
+
+  test('previewEnvImport reports recognized variables', () {
+    final preview = cubit.previewEnvImport('OPENAI_API_KEY=sk-1\nRANDOM=2\n');
+    expect(preview.recognized.keys, ['OPENAI_API_KEY']);
+    expect(preview.unrecognized, ['RANDOM']);
+  });
+
+  test('importEnvVariables applies values and sets a summary message', () async {
+    await cubit.importEnvVariables({'OPENAI_API_KEY': 'sk-1'});
+
+    expect(cubit.state.envImportMessage, contains('1'));
+    expect(aiSettingsService.openaiSettings.apiKey, 'sk-1');
+  });
+}

--- a/test/pages/settings/state/settings_cubit_sync_test.dart
+++ b/test/pages/settings/state/settings_cubit_sync_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
 import 'package:pinboard_wizard/src/backup/backup_service.dart';
@@ -24,8 +25,8 @@ void main() {
   late GitHubCredentialsStorage githubStorage;
   late GitHubAuthService githubAuthService;
 
-  setUp(() async {
-    fake = FakeFlutterSecureStorage();
+  Future<void> initWith(FakeFlutterSecureStorage storageFake) async {
+    fake = storageFake;
     appStorage = AppSecureStorage(storage: fake);
     await appStorage.init();
     secretStorage = FlutterSecureSecretsStorage(storage: appStorage);
@@ -49,7 +50,9 @@ void main() {
         githubAuthService: githubAuthService,
       ),
     );
-  });
+  }
+
+  setUp(() => initWith(FakeFlutterSecureStorage()));
 
   tearDown(() => cubit.close());
 
@@ -69,6 +72,30 @@ void main() {
     expect(fake.synced['pinboard_credentials'], '{"apiKey":"user:abc"}');
   });
 
+  test(
+    'setSecretsSyncEnabled failure keeps the flag off and surfaces the error',
+    () async {
+      await cubit.close();
+      final throwing = _ThrowingSyncStorage(
+        throwOnWriteOf: 'pinboard_credentials',
+      );
+      await initWith(throwing);
+      throwing.local['pinboard_credentials'] = '{"apiKey":"user:abc"}';
+
+      await cubit.setSecretsSyncEnabled(true);
+
+      expect(cubit.state.secretsSyncEnabled, isFalse);
+      expect(cubit.state.syncErrorMessage, isNotNull);
+      expect(cubit.state.syncErrorMessage, contains('enable'));
+
+      // Retry once the keychain cooperates: succeeds and clears the error.
+      throwing.throwOnWriteOf = null;
+      await cubit.setSecretsSyncEnabled(true);
+      expect(cubit.state.secretsSyncEnabled, isTrue);
+      expect(cubit.state.syncErrorMessage, isNull);
+    },
+  );
+
   test('previewEnvImport reports recognized variables', () {
     final preview = cubit.previewEnvImport('OPENAI_API_KEY=sk-1\nRANDOM=2\n');
     expect(preview.recognized.keys, ['OPENAI_API_KEY']);
@@ -84,4 +111,37 @@ void main() {
       expect(aiSettingsService.openaiSettings.apiKey, 'sk-1');
     },
   );
+}
+
+/// Throws on writes of one configurable key; everything else behaves normally.
+class _ThrowingSyncStorage extends FakeFlutterSecureStorage {
+  _ThrowingSyncStorage({required this.throwOnWriteOf});
+
+  String? throwOnWriteOf;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (key == throwOnWriteOf) {
+      throw Exception('keychain write denied');
+    }
+    return super.write(
+      key: key,
+      value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
 }

--- a/test/pages/settings/state/settings_cubit_test.dart
+++ b/test/pages/settings/state/settings_cubit_test.dart
@@ -6,13 +6,18 @@ import 'package:pinboard_wizard/src/ai/ai_settings.dart';
 import 'package:pinboard_wizard/src/ai/ai_settings_service.dart';
 import 'package:pinboard_wizard/src/backup/backup_service.dart';
 import 'package:pinboard_wizard/src/backup/models/s3_config.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/env_import/env_import_service.dart';
 import 'package:pinboard_wizard/src/github/github_auth_service.dart';
+import 'package:pinboard_wizard/src/github/github_credentials_storage.dart';
 import 'package:pinboard_wizard/src/github/models/models.dart';
 import 'package:pinboard_wizard/src/pages/settings/state/settings_cubit.dart';
 import 'package:pinboard_wizard/src/pages/settings/state/settings_state.dart';
 import 'package:pinboard_wizard/src/pinboard/credentials_service.dart';
 import 'package:pinboard_wizard/src/pinboard/models/credentials.dart';
 import 'package:pinboard_wizard/src/pinboard/pinboard_service.dart';
+
+import '../../../common/storage/fake_flutter_secure_storage.dart';
 
 class MockCredentialsService extends Mock implements CredentialsService {
   @override
@@ -296,12 +301,24 @@ void main() {
       when(mockGitHubAuthService.isAuthenticated).thenReturn(false);
       when(mockGitHubAuthService.currentWarning).thenReturn(null);
 
+      final appSecureStorage = AppSecureStorage(
+        storage: FakeFlutterSecureStorage(),
+      );
+
       settingsCubit = SettingsCubit(
         credentialsService: mockCredentialsService,
         pinboardService: mockPinboardService,
         aiSettingsService: mockAiSettingsService,
         backupService: mockBackupService,
         githubAuthService: mockGitHubAuthService,
+        appSecureStorage: appSecureStorage,
+        envImportService: EnvImportService(
+          credentialsService: mockCredentialsService,
+          aiSettingsService: mockAiSettingsService,
+          backupService: mockBackupService,
+          githubStorage: GitHubCredentialsStorage(storage: appSecureStorage),
+          githubAuthService: mockGitHubAuthService,
+        ),
       );
     });
 

--- a/test/pinboard/flutter_secure_secrets_storage_test.dart
+++ b/test/pinboard/flutter_secure_secrets_storage_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pinboard_wizard/src/common/storage/app_secure_storage.dart';
+import 'package:pinboard_wizard/src/pinboard/flutter_secure_secrets_storage.dart';
+import 'package:pinboard_wizard/src/pinboard/models/credentials.dart';
+
+import '../common/storage/fake_flutter_secure_storage.dart';
+
+void main() {
+  late FakeFlutterSecureStorage fake;
+  late AppSecureStorage appStorage;
+  late FlutterSecureSecretsStorage storage;
+
+  setUp(() async {
+    fake = FakeFlutterSecureStorage();
+    appStorage = AppSecureStorage(storage: fake);
+    await appStorage.init();
+    storage = FlutterSecureSecretsStorage(storage: appStorage);
+  });
+
+  test('save and read round-trips credentials as JSON', () async {
+    await storage.save(const Credentials(apiKey: 'user:abcdef0123456789'));
+    final result = await storage.read();
+    expect(result, const Credentials(apiKey: 'user:abcdef0123456789'));
+    expect(fake.local['pinboard_credentials'], contains('user:abcdef0123456789'));
+  });
+
+  test('read returns null when nothing stored', () async {
+    expect(await storage.read(), isNull);
+  });
+
+  test('read returns null on corrupt JSON', () async {
+    fake.local['pinboard_credentials'] = 'not-json';
+    expect(await storage.read(), isNull);
+  });
+
+  test('clear removes stored credentials', () async {
+    await storage.save(const Credentials(apiKey: 'user:abcdef0123456789'));
+    await storage.clear();
+    expect(await storage.read(), isNull);
+    expect(await storage.hasCredentials(), isFalse);
+  });
+
+  test('hasCredentials reflects stored state', () async {
+    expect(await storage.hasCredentials(), isFalse);
+    await storage.save(const Credentials(apiKey: 'user:abcdef0123456789'));
+    expect(await storage.hasCredentials(), isTrue);
+  });
+
+  test('credentials written while synced are read back through synced set', () async {
+    await appStorage.setSyncEnabled(true);
+    await storage.save(const Credentials(apiKey: 'user:abcdef0123456789'));
+    expect(fake.synced.containsKey('pinboard_credentials'), isTrue);
+    expect(await storage.read(), const Credentials(apiKey: 'user:abcdef0123456789'));
+  });
+}

--- a/test/pinboard/flutter_secure_secrets_storage_test.dart
+++ b/test/pinboard/flutter_secure_secrets_storage_test.dart
@@ -21,7 +21,10 @@ void main() {
     await storage.save(const Credentials(apiKey: 'user:abcdef0123456789'));
     final result = await storage.read();
     expect(result, const Credentials(apiKey: 'user:abcdef0123456789'));
-    expect(fake.local['pinboard_credentials'], contains('user:abcdef0123456789'));
+    expect(
+      fake.local['pinboard_credentials'],
+      contains('user:abcdef0123456789'),
+    );
   });
 
   test('read returns null when nothing stored', () async {
@@ -46,10 +49,16 @@ void main() {
     expect(await storage.hasCredentials(), isTrue);
   });
 
-  test('credentials written while synced are read back through synced set', () async {
-    await appStorage.setSyncEnabled(true);
-    await storage.save(const Credentials(apiKey: 'user:abcdef0123456789'));
-    expect(fake.synced.containsKey('pinboard_credentials'), isTrue);
-    expect(await storage.read(), const Credentials(apiKey: 'user:abcdef0123456789'));
-  });
+  test(
+    'credentials written while synced are read back through synced set',
+    () async {
+      await appStorage.setSyncEnabled(true);
+      await storage.save(const Credentials(apiKey: 'user:abcdef0123456789'));
+      expect(fake.synced.containsKey('pinboard_credentials'), isTrue);
+      expect(
+        await storage.read(),
+        const Credentials(apiKey: 'user:abcdef0123456789'),
+      );
+    },
+  );
 }

--- a/test/ui/facade_smoke_test.dart
+++ b/test/ui/facade_smoke_test.dart
@@ -34,51 +34,55 @@ class _WallpaperStubBundle extends CachingAssetBundle {
 }
 
 Widget _host(Widget child) => DefaultAssetBundle(
-      bundle: _WallpaperStubBundle(),
-      child: LiquidGlassWidgets.wrap(
-        child: MaterialApp(
-          theme: appLightTheme(),
-          home: Scaffold(body: child),
-        ),
-      ),
-    );
+  bundle: _WallpaperStubBundle(),
+  child: LiquidGlassWidgets.wrap(
+    child: MaterialApp(
+      theme: appLightTheme(),
+      home: Scaffold(body: child),
+    ),
+  ),
+);
 
 void main() {
   testWidgets('facade controls build', (tester) async {
-    await tester.pumpWidget(_host(
-      Column(
-        children: [
-          AppButton(onPressed: () {}, child: const Text('Go')),
-          AppButton(onPressed: null, child: const Text('Off')),
-          AppIconButton(icon: const Icon(Icons.add), onPressed: () {}),
-          AppSwitch(value: true, onChanged: (_) {}),
-          AppCheckbox(value: true, onChanged: (_) {}),
-          AppRadio<int>(value: 1, groupValue: 1, onChanged: (_) {}),
-          const AppProgress(),
-          const AppTooltip(message: 'hi', child: Icon(Icons.info)),
-          const AppListTile(title: Text('Tile')),
-        ],
+    await tester.pumpWidget(
+      _host(
+        Column(
+          children: [
+            AppButton(onPressed: () {}, child: const Text('Go')),
+            AppButton(onPressed: null, child: const Text('Off')),
+            AppIconButton(icon: const Icon(Icons.add), onPressed: () {}),
+            AppSwitch(value: true, onChanged: (_) {}),
+            AppCheckbox(value: true, onChanged: (_) {}),
+            AppRadio<int>(value: 1, groupValue: 1, onChanged: (_) {}),
+            const AppProgress(),
+            const AppTooltip(message: 'hi', child: Icon(Icons.info)),
+            const AppListTile(title: Text('Tile')),
+          ],
+        ),
       ),
-    ));
+    );
     expect(find.text('Go'), findsOneWidget);
     expect(find.byType(AppSwitch), findsOneWidget);
     expect(find.byType(AppProgress), findsOneWidget);
   });
 
   testWidgets('window scaffold + sidebar build', (tester) async {
-    await tester.pumpWidget(_host(
-      GlassWindowScaffold(
-        sidebar: GlassSidebar(
-          items: const [
-            GlassSidebarItem(icon: Icons.star, label: 'A'),
-            GlassSidebarItem(icon: Icons.book, label: 'B'),
-          ],
-          selectedIndex: 0,
-          onSelected: (_) {},
+    await tester.pumpWidget(
+      _host(
+        GlassWindowScaffold(
+          sidebar: GlassSidebar(
+            items: const [
+              GlassSidebarItem(icon: Icons.star, label: 'A'),
+              GlassSidebarItem(icon: Icons.book, label: 'B'),
+            ],
+            selectedIndex: 0,
+            onSelected: (_) {},
+          ),
+          body: const Center(child: Text('content')),
         ),
-        body: const Center(child: Text('content')),
       ),
-    ));
+    );
     expect(find.text('content'), findsOneWidget);
     expect(find.text('A'), findsOneWidget);
   });


### PR DESCRIPTION
## Summary

Two features for managing credentials across machines:

1. **iCloud Keychain sync (opt-in)** — all five credential groups (Pinboard token, OpenAI key, Jina key, S3 backup config, GitHub notes config + PAT) can sync across Macs via iCloud Keychain. New `AppSecureStorage` centralizes keychain access and owns the `synchronizable` attribute; the four credential services now inject it. Settings gains a **Sync** tab with the toggle (default **OFF**, per-Mac opt-in).
2. **One-time `.env` import** — "Import from .env…" on the Sync tab reads a user-picked env file once and applies recognized variables through the existing services (13 variables; env value wins; absent keys untouched; empty values ignored; masked-value confirmation dialog before anything is written).

Design spec: `docs/superpowers/specs/2026-07-10-credential-sync-and-env-import-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-10-credential-sync-and-env-import.md`

## Key semantics

- Sync flag itself is a local-only keychain entry; enabling migrates per key with **synced-value-wins**, two-phase (all writes, then local deletions) so partial failure never hides credentials.
- Disabling snapshots synced values locally and **never deletes synchronizable items** — deletion would propagate to every Mac.
- Env import is explicit-action only; the file is never read at launch. README documents variables and rules.

## Verification

- `fvm flutter analyze` — No issues found
- `fvm flutter test` — 676 passing / ~10 skips (baseline before branch: 618)
- `fvm flutter build macos --debug` — builds
- Every task reviewed (spec + quality) by an independent reviewer; final whole-branch review verdict: ready to merge. Review history in `.superpowers/sdd/progress-credential-sync.md`.

## Manual cross-Mac smoke checklist (not CI-testable)

1. Mac A: configure Pinboard token, enable Settings → Sync. Keychain Access shows the items in the iCloud keychain.
2. Mac B (same iCloud account, iCloud Keychain on): enable Sync → Pinboard token appears; app authenticates.
3. Mac B: change the OpenAI key → Mac A relaunch sees the new key.
4. Mac B: disable sync, change Jina key → Mac A unchanged (intentional divergence).
5. Mac B: re-enable sync → adopts the synced values again (synced-wins).
6. In-app: Sync tab renders 5th; import dialog masks values; `.env` dotfiles need Cmd+Shift+. in the open panel; cancel on the enable dialog leaves the toggle off; a migration failure shows an error under the toggle.

## Non-blocking follow-ups (from review)

- Consider hoisting `hasCredentials()` into the `SecretStorage` interface (removes a downcast).
- README has two env-var mentions (pre-existing "Environment Variables" section vs new import docs) — docs tidy.
- `BackupService.loadConfiguration` entry-reset could be conditional on error status only.
- `EnvFileParser` line-split regex could be static.
